### PR TITLE
Landing: change alignment of usage-text labels to prevent jumping on switch

### DIFF
--- a/styles/pages/landing.css
+++ b/styles/pages/landing.css
@@ -106,7 +106,6 @@
 .landing-usage-text {
   font: var(--text-caption);
   color: var(--color-foreground-1);
-  align-self: center;
   max-width: 30em;
 
   & h2 {


### PR DESCRIPTION
Feel free to close if you prefer the original behavior 👍🏼 Cheers!

Before:
https://user-images.githubusercontent.com/1460122/167318759-72542fe0-ad36-4a3d-b99d-24ead88694e2.mp4

After:
https://user-images.githubusercontent.com/1460122/167318775-1775a139-ba69-4a96-a3c8-c572711674e8.mp4


