### PR TITLE
Fix typos on URLs page

### DIFF
--- a/docs/creating-pages/urls.md
+++ b/docs/creating-pages/urls.md
@@ -105,7 +105,7 @@ Now, all pages in the post directory share the same `url` function, that returns
 the title of the page as a relative URL, for example `./My first post/` (See
 [Shared data](../creating-pages/shared-data.md)).
 
-Due the URL is relative, the current directory is appended automatically (it
+Because the URL is relative, the current directory is appended automatically (it
 will be resolved to `/post/My first post/`). And if you are using the
 [`slugify_urls`](../../plugins/slugify_urls.md) plugin all output paths are
 slugified automatically, so the final url will be `/post/my-first-post/`.

--- a/docs/creating-pages/urls.md
+++ b/docs/creating-pages/urls.md
@@ -14,7 +14,7 @@ posts/my-first-post.md  =>  /posts/my-first-post/index.html
 ```
 
 By default, the pages are saved as "pretty URLs", using directories for the path
-and a `index.html` file. So the final URL is `/posts/my-fist-post/`. To disable
+and a `index.html` file. So the final URL is `/posts/my-first-post/`. To disable
 this behaviour, set the option `prettyUrls` to `false` in your `_config.js` file
 (see [Configuration](../configuration/config-file.md)).
 
@@ -68,7 +68,7 @@ For example:
 
 ```yml
 ---
-title: My fist post
+title: My first post
 url: ./welcome/
 ---
 ```
@@ -108,7 +108,7 @@ the title of the page as a relative URL, for example `./My first post/` (See
 Due the URL is relative, the current directory is appended automatically (it
 will be resolved to `/post/My first post/`). And if you are using the
 [`slugify_urls`](../../plugins/slugify_urls.md) plugin all output paths are
-slugified automatically, so the final url will be `/post/my-fist-post/`.
+slugified automatically, so the final url will be `/post/my-first-post/`.
 
 Using functions as URLs gives a lot of flexibility to generate the URLs as you
 want.


### PR DESCRIPTION
Thanks for creating a great project -- I'm new to Lume but it seems like a great framework so far!

I noticed a couple of small typos in the docs for the URLs page which I thought might the examples to understand. This PR fixes:

1. Changing instances of 'fist' to 'first', to match the rest of the example.
2. Changing 'Due' to 'Because'.

I'm less confident about (2), but if I understood the intended meaning of the sentence, then I think it preserves the meaning without changing the sentence structure. An alternative might have been 'Due to the fact that the URL is relative...'.

Thanks again!