### PR TITLE
Add markdown-it plugins config docs

### DIFF
--- a/plugins/markdown.md
+++ b/plugins/markdown.md
@@ -65,7 +65,7 @@ This will override the default plugins with yours. If you only want to add more
 plugins without remove the defaults, use the `keepDefaultPlugins` option:
 
 ```ts
-// Add more markdown plugins without override the defaults
+// Add more markdown plugins without overriding the defaults
 const markdown = {
   plugins: [anchor],
   keepDefaultPlugins: true,

--- a/plugins/markdown.md
+++ b/plugins/markdown.md
@@ -36,6 +36,21 @@ const site = lume({}, { markdown });
 export default site;
 ```
 
+Use the `options` property to change the
+[markdown-it settings](https://github.com/markdown-it/markdown-it#usage-examples):
+
+```ts
+// Change markdown-it configuration
+const markdown = {
+  options: {
+    breaks: false,
+    xhtmlOut: true,
+  },
+};
+
+const site = lume({}, { markdown });
+```
+
 ### Plugins
 
 Lume uses [markdown-it](https://github.com/markdown-it/markdown-it) as the

--- a/plugins/markdown.md
+++ b/plugins/markdown.md
@@ -89,20 +89,24 @@ const markdown = {
 const site = lume({}, { markdown });
 ```
 
-Use the `options` property to change the
-[markdown-it settings](https://github.com/markdown-it/markdown-it#usage-examples):
+You can pass options to your markdown-it plugins (as opposed to the markdown-it engine
+itself) like so:
 
 ```ts
-// Change markdown-it configuration
+import anchor from "https://jspm.dev/markdown-it-anchor";
+import footnote from "https://jspm.dev/markdown-it-footnote";
+
+// Pass options to markdown-it plugins
 const markdown = {
-  options: {
-    breaks: false,
-    xhtmlOut: true,
-  },
+  plugins: [[anchor, { level: 2 }], footnote],
+  keepDefaultPlugins: true,
 };
 
 const site = lume({}, { markdown });
 ```
+
+(When an array is passed as an element of `plugins`, its value will be spread
+into the `.use()` call on the markdown engine.)
 
 ## Creating pages in Markdown
 

--- a/plugins/markdown.md
+++ b/plugins/markdown.md
@@ -61,7 +61,7 @@ markdown parser, with the following plugins enabled:
 - [markdown-it-attrs](https://github.com/arve0/markdown-it-attrs) to add support
   for CSS classes and other attributes using `{}`.
 
-Use the option `plugins` to replace them. For example, to add the
+Use the `plugins` option to replace them. For example, to add the
 [markdown-it-anchor](https://github.com/valeriangalliat/markdown-it-anchor)
 plugin:
 

--- a/plugins/markdown.md
+++ b/plugins/markdown.md
@@ -128,8 +128,8 @@ Markdown in _inline_ mode.
 
 ```html
 <!-- Render to HTML code -->
-<div>{{ text | md }}<div>
+<div>{{ text | md }}</div>
 
 <!-- Single line rendering, without the paragraph wrap: -->
-<p>{{ text | md(true) }}<p>
+<p>{{ text | md(true) }}</p>
 ```


### PR DESCRIPTION
Following [Issue #212](https://github.com/lumeland/lume/issues/212) in the main lume repo, this adds an example of how to pass config options to markdown-it plugins.

I found it quite hard to express this in a clear way, because of the way we need to talk about plugins in two senses (the markdown-it plugin for lume and e.g. the anchor plugin for markdown-it) and the separate ways of setting options for these two kinds of plugin. I moved the markdown-it options example up to the general 'config' section, which I'm hoping might help make the distinction clear. But I'm not confident that I've found a clear and concise way of spelling out the example, so I'm happy to revise this PR if you don't think it's clear.

I also made a couple of other small changes to separate parts of the page, to fix a couple of typos. I hope you don't mind!