### PR TITLE
Fix default branch and entrypoint

### DIFF
--- a/docs/advanced/deployment.md
+++ b/docs/advanced/deployment.md
@@ -44,7 +44,7 @@ name: Publish on GitHub Pages
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:
@@ -131,7 +131,7 @@ name: Publish on Deno Deploy
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:
@@ -157,7 +157,7 @@ jobs:
         with:
           project: project-name
           import-map: "./import_map.json"
-          entrypoint: server.ts
+          entrypoint: serve.ts
 ```
 
 ## Netlify


### PR DESCRIPTION
GitHub's default branch name is now `main`. Also, in this document the entrypoint's file name first appears as `serve.ts`, so fixed it. 