### PR TITLE
Optimized lume-code tabs

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -56,6 +56,50 @@ site
     if (toc && header) {
       header.appendChild(toc);
     }
+
+    const blocks = doc.querySelectorAll("lume-code");
+
+    blocks.forEach((block, i) => {
+      const pres = (block as unknown as HTMLElement).querySelectorAll(
+        ":scope > pre",
+      );
+
+      const menu = doc.createElement("ul");
+      menu.classList.add("lume-code-menu");
+      menu.setAttribute("role", "tablist");
+      menu.setAttribute("aria-label", "Code Tabs");
+
+      pres.forEach((pre, j) => {
+        const title = pre.querySelector("code")!.getAttribute("title")!;
+
+        const li = doc.createElement("li");
+
+        const button = doc.createElement("button");
+        button.classList.add("lume-code-tab");
+        button.setAttribute("role", "tab");
+        button.setAttribute("aria-selected", j === 0 ? true : false);
+        button.setAttribute("aria-controls", `panel-${i + 1}-${j + 1}`);
+        button.setAttribute("id", `tab-${i + 1}-${j + 1}`);
+        button.setAttribute("tabindex", j === 0 ? 0 : -1);
+        button.innerText = title;
+
+        if (j > 0) {
+          pre["setAttribute"]("hidden", "true");
+        } else {
+          button.classList.add("is-active");
+        }
+
+        pre["setAttribute"]("role", "tabpanel");
+        pre["setAttribute"]("aria-labelledby", `tab-${i + 1}-${j + 1}`);
+        pre["setAttribute"]("id", `panel-${i + 1}-${j + 1}`);
+        pre["setAttribute"]("tabindex", "0");
+
+        li.append(button);
+        menu.appendChild(li);
+      });
+
+      (block as unknown as HTMLElement).prepend(menu as unknown as Node);
+    });
   });
 
 export default site;

--- a/_config.ts
+++ b/_config.ts
@@ -65,9 +65,9 @@ site
       );
 
       const menu = doc.createElement("ul");
-      menu.classList.add("lume-code-menu");
       menu.setAttribute("role", "tablist");
       menu.setAttribute("aria-label", "Code Tabs");
+      menu.classList.add("lume-code-menu");
 
       pres.forEach((pre, j) => {
         const title = pre.querySelector("code")!.getAttribute("title")!;
@@ -75,24 +75,24 @@ site
         const li = doc.createElement("li");
 
         const button = doc.createElement("button");
-        button.classList.add("lume-code-tab");
         button.setAttribute("role", "tab");
         button.setAttribute("aria-selected", j === 0 ? true : false);
         button.setAttribute("aria-controls", `panel-${i + 1}-${j + 1}`);
         button.setAttribute("id", `tab-${i + 1}-${j + 1}`);
         button.setAttribute("tabindex", j === 0 ? 0 : -1);
         button.innerText = title;
+        button.classList.add("lume-code-tab");
 
         if (j > 0) {
-          pre["setAttribute"]("hidden", "true");
+          pre.setAttribute("hidden", "true");
         } else {
           button.classList.add("is-active");
         }
 
-        pre["setAttribute"]("role", "tabpanel");
-        pre["setAttribute"]("aria-labelledby", `tab-${i + 1}-${j + 1}`);
-        pre["setAttribute"]("id", `panel-${i + 1}-${j + 1}`);
-        pre["setAttribute"]("tabindex", "0");
+        pre.setAttribute("role", "tabpanel");
+        pre.setAttribute("aria-labelledby", `tab-${i + 1}-${j + 1}`);
+        pre.setAttribute("id", `panel-${i + 1}-${j + 1}`);
+        pre.setAttribute("tabindex", "0");
 
         li.append(button);
         menu.appendChild(li);

--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,14 @@
 {
   "importMap": "import_map.json",
+  "compilerOptions": {
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "dom.asynciterable",
+      "deno.ns",
+      "deno.unstable"
+    ]
+  },
   "tasks": {
     "build": "deno task lume",
     "serve": "deno task lume -s",

--- a/scripts/components/lume_code.js
+++ b/scripts/components/lume_code.js
@@ -1,27 +1,70 @@
+// ARIA: tab role, best practices: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role
+// customElements eventListener: https://www.jonasfaehrmann.com/writing/post/2021-02-01-custom-elements-event-listener-and-this/
+
 export default class LumeCode extends HTMLElement {
+  constructor() {
+    super();
+    this.tabFocus = 0;
+    this.tabs = this.querySelectorAll('[role="tab"]');
+    this.tabList = this.querySelector('[role="tablist"]');
+    this.buttonBoundListener = this.handleTabChange.bind(this);
+    this.keydownBoundListener = this.handleKeyPress.bind(this);
+  }
+
   connectedCallback() {
-    const blocks = this.querySelectorAll(":scope > pre");
-    const menu = document.createElement("ul");
-    menu.classList.add("lume-code-menu");
+    this.tabs.forEach((tab) => {
+      tab.addEventListener("click", this.buttonBoundListener);
+    });
 
-    for (const block of blocks) {
-      const title = block.querySelector("code").title;
-      const li = document.createElement("li");
-      const button = document.createElement("button");
-      button.innerText = title;
-      button.classList.add("lume-code-tab");
-      button.addEventListener("click", () => {
-        blocks.forEach((el) => el.hidden = el !== block);
-        this.querySelectorAll("button.is-active").forEach((el) =>
-          el.classList.remove("is-active")
-        );
-        button.classList.add("is-active");
-      });
-      li.append(button);
-      menu.append(li);
+    this.tabList.addEventListener("keydown", this.keydownBoundListener);
+  }
+
+  handleKeyPress(e) {
+    if (e.keyCode === 39 || e.keyCode === 37) {
+      this.tabs[this.tabFocus].setAttribute("tabindex", -1);
+      if (e.keyCode === 39) {
+        this.tabFocus++;
+        if (this.tabFocus >= this.tabs.length) {
+          this.tabFocus = 0;
+        }
+      } else if (e.keyCode === 37) {
+        this.tabFocus--;
+        if (this.tabFocus < 0) {
+          this.tabFocus = this.tabs.length - 1;
+        }
+      }
+
+      this.tabs[this.tabFocus].setAttribute("tabindex", 0);
+      this.tabs[this.tabFocus].focus();
     }
-    this.prepend(menu);
+  }
 
-    this.querySelector("button").click();
+  handleTabChange(e) {
+    const target = e.target;
+    const parent = target.parentNode;
+    const grandparent = parent.parentNode;
+
+    const current = target.getAttribute("aria-controls");
+
+    grandparent.querySelectorAll('[aria-selected="true"]').forEach((t) => {
+      if (t === target) return;
+      t.setAttribute("aria-selected", false);
+      t.setAttribute("tabindex", -1);
+      t.classList.remove("is-active");
+    });
+
+    target.setAttribute("aria-selected", true);
+    target.setAttribute("tabindex", 0);
+    target.classList.add("is-active");
+
+    grandparent.parentNode.querySelectorAll('[role="tabpanel"]').forEach(
+      (p) => {
+        if (p.id === current) {
+          p.removeAttribute("hidden");
+        } else {
+          p.setAttribute("hidden", true);
+        }
+      },
+    );
   }
 }


### PR DESCRIPTION
This PR fixes a wired Layout Shift from `<lume-code>` blocks.

- Moved `creation of <lume-code> tabs` from run-time to build-time
- Rewritten `<lume-code>` as ARIA: tab role, using best practices & keyboard events

> For TypeScript compability it was required to add `dom` to `libs`. For more info see [deno docs](https://deno.land/manual@v1.25.1/typescript/configuration#using-the-lib-property).