### PR TITLE
Extra closing parenthesis deleted

### DIFF
--- a/plugins/paginate.md
+++ b/plugins/paginate.md
@@ -27,7 +27,7 @@ export default function* ({ search, paginate }) {
     size: 10
   };
 
-  for (const page of paginate(posts, options))) {
+  for (const page of paginate(posts, options)) {
     yield page;
   }
 }


### PR DESCRIPTION
plugins/paginate.md

Extra closing parenthesis deleted

```js
for (const page of paginate(posts, options))) <-- extra
```


```
Caused by TypeError: The module's source code could not be parsed: Unexpected token ')'.
```