### PR TITLE
Updated GitHub Pages workflow

### DIFF
--- a/docs/advanced/deployment.md
+++ b/docs/advanced/deployment.md
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Deno environment
         uses: denoland/setup-deno@v1
@@ -58,7 +58,7 @@ jobs:
         run: deno task build
 
       - name: Deploy
-        uses: crazy-max/ghaction-github-pages@v2.0.1
+        uses: crazy-max/ghaction-github-pages@v3
         with:
           build_dir: _site
         env:


### PR DESCRIPTION
Updated [actions/checkout](https://github.com/actions/checkout) to v3 and [crazy-max/ghaction-github-pages](https://github.com/crazy-max/ghaction-github-pages) to v3. The previous workflow was causing the warning shown below:

<img width="1069" alt="Screenshot 2022-11-01 at 8 30 10 PM" src="https://user-images.githubusercontent.com/8847625/199388851-c4a62353-35bc-4ff6-8fa0-ff41a3130542.png">
