### PR TITLE
Remove unneeded period from start of line

### DIFF
--- a/docs/core/server.md
+++ b/docs/core/server.md
@@ -160,5 +160,5 @@ server.use(www({
 }));
 ```
 
-. See the
+See the
 [available options in Deno Doc](https://doc.deno.land/https://deno.land/x/lume/middlewares/www.ts/~/Options).


### PR DESCRIPTION
The period was at the beginning of the line and unneeded, so I removed it.