### PR TITLE
feat: improve fire visual

### DIFF
--- a/_components/fire.njk
+++ b/_components/fire.njk
@@ -66,7 +66,7 @@
   }
   .flame:nth-child(1),
   .flame:nth-child(1)::after {
-    animation-delay: 0.14s;
+    animation-delay: -0.14s;
   }
   .flame:nth-child(1) {
     margin-left: 0.8em;
@@ -74,7 +74,7 @@
   }
   .flame:nth-child(2),
   .flame:nth-child(2)::after {
-    animation-delay: 0.28s;
+    animation-delay: -0.28s;
   }
   .flame:nth-child(2) {
     margin-left: 1.1em;
@@ -82,7 +82,7 @@
   }
   .flame:nth-child(3),
   .flame:nth-child(3)::after {
-    animation-delay: 0.42s;
+    animation-delay: -0.42s;
   }
   .flame:nth-child(3) {
     margin-left: 3.8em;
@@ -90,7 +90,7 @@
   }
   .flame:nth-child(4),
   .flame:nth-child(4)::after {
-    animation-delay: 0.56s;
+    animation-delay: -0.56s;
   }
   .flame:nth-child(4) {
     margin-left: 1.8em;
@@ -98,7 +98,7 @@
   }
   .flame:nth-child(5),
   .flame:nth-child(5)::after {
-    animation-delay: 0.7s;
+    animation-delay: -0.7s;
   }
   .flame:nth-child(5) {
     margin-left: 3.8em;
@@ -106,7 +106,7 @@
   }
   .flame:nth-child(6),
   .flame:nth-child(6)::after {
-    animation-delay: 0.84s;
+    animation-delay: -0.84s;
   }
   .flame:nth-child(6) {
     margin-left: 3.3em;
@@ -114,7 +114,7 @@
   }
   .flame:nth-child(7),
   .flame:nth-child(7)::after {
-    animation-delay: 0.98s;
+    animation-delay: -0.98s;
   }
   .flame:nth-child(7) {
     margin-left: 4em;
@@ -122,7 +122,7 @@
   }
   .flame:nth-child(8),
   .flame:nth-child(8)::after {
-    animation-delay: 1.12s;
+    animation-delay: -1.12s;
   }
   .flame:nth-child(8) {
     margin-left: 0.1em;
@@ -130,7 +130,7 @@
   }
   .flame:nth-child(9),
   .flame:nth-child(9)::after {
-    animation-delay: 1.26s;
+    animation-delay: -1.26s;
   }
   .flame:nth-child(9) {
     margin-left: 4.2em;
@@ -138,7 +138,7 @@
   }
   .flame:nth-child(10),
   .flame:nth-child(10)::after {
-    animation-delay: 1.4s;
+    animation-delay: -1.4s;
   }
   .flame:nth-child(10) {
     margin-left: 1.8em;
@@ -146,7 +146,7 @@
   }
   .flame:nth-child(11),
   .flame:nth-child(11)::after {
-    animation-delay: 1.54s;
+    animation-delay: -1.54s;
   }
   .flame:nth-child(11) {
     margin-left: 3.8em;
@@ -154,7 +154,7 @@
   }
   .flame:nth-child(12),
   .flame:nth-child(12)::after {
-    animation-delay: 1.68s;
+    animation-delay: -1.68s;
   }
   .flame:nth-child(12) {
     margin-left: 0.2em;
@@ -162,7 +162,7 @@
   }
   .flame:nth-child(13),
   .flame:nth-child(13)::after {
-    animation-delay: 1.82s;
+    animation-delay: -1.82s;
   }
   .flame:nth-child(13) {
     margin-left: 0.1em;
@@ -170,7 +170,7 @@
   }
   .flame:nth-child(14),
   .flame:nth-child(14)::after {
-    animation-delay: 1.96s;
+    animation-delay: -1.96s;
   }
   .flame:nth-child(14) {
     margin-left: 2.1em;
@@ -178,7 +178,7 @@
   }
   .flame:nth-child(15),
   .flame:nth-child(15)::after {
-    animation-delay: 2.1s;
+    animation-delay: -2.1s;
   }
   .flame:nth-child(15) {
     margin-left: 0.9em;


### PR DESCRIPTION
# Summary

|      before       |      after      |
| :---------------: | :-------------: |
| ![before][before] | ![after][after] |

improve lume.land front page fire visual by starting animation from [middle of the keyframe](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-delay#values).

[after]: https://user-images.githubusercontent.com/54838975/222389955-87e5f3c4-65ef-4f0f-91ee-4b38571fbb86.gif
[before]: https://user-images.githubusercontent.com/54838975/222389965-dac18250-d51e-4c1f-91bb-a6f0167a90d7.gif
