### PR TITLE
ScopeFilter function example should return a boolean

### DIFF
--- a/docs/configuration/ignore-files.md
+++ b/docs/configuration/ignore-files.md
@@ -30,5 +30,7 @@ Example:
 
 ```js
 // Ignore all files with ".md" extension inside the "draft" folder
-site.ignore((path) => path.match(/^\/draft\/.*\.md$/));
+site.ignore((path) => {
+  return path.match(/^\/draft\/.*\.md$/) !== null;
+});
 ```


### PR DESCRIPTION
The example code for passing a ScopeFilter function to `site.ignore` doesn't compile. The signature for ScopeFilter specifies that it should return a boolean, but [`String.prototype.match` returns either an Array or `null`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#return_value).

```js
export type ScopeFilter = (path: string) => boolean;
```

https://github.com/lumeland/lume/blob/be25eb894e6886cdaf4552188b88ad4e5b61b39c/core/scopes.ts#L61

This branch updates the example function to return a boolean, but should otherwise preserve the intended functionality for the example filter.