### PR TITLE
Update installation.md

### DIFF
--- a/docs/overview/installation.md
+++ b/docs/overview/installation.md
@@ -26,7 +26,7 @@ This command creates the following files:
   It includes the import map and some tasks to run Lume. You can also configure
   other features of Deno like TypeScript, formatter, linter, etc.
 
-Here is an example of these three configuration files:
+Here is an example of these two configuration files:
 
 <lume-code>
 
@@ -101,7 +101,7 @@ to define this variable:
 {
   "importMap": "import_map.json",
   "tasks": {
-    "lume": "DENO_DIR=_vendor echo \"import 'lume/cli.ts'\" | deno run --unstable -A -",
+    "lume": "DENO_DIR=_vendor; echo \"import 'lume/cli.ts'\" | deno run --unstable -A -",
     "build": "deno task lume",
     "serve": "deno task lume -s"
   }

--- a/docs/overview/installation.md
+++ b/docs/overview/installation.md
@@ -101,7 +101,7 @@ to define this variable:
 {
   "importMap": "import_map.json",
   "tasks": {
-    "lume": "DENO_DIR=_vendor; echo \"import 'lume/cli.ts'\" | deno run --unstable -A -",
+    "lume": "DENO_DIR=_vendor echo \"import 'lume/cli.ts'\" | deno run --unstable -A -",
     "build": "deno task lume",
     "serve": "deno task lume -s"
   }


### PR DESCRIPTION
1. correct counting number of config files in Setup section 
2. fix command in Vendor section


As for (1), I believe we only have 2 files as `import_map.json` is merged into `deno.json`.

As for (2), I'm not sure why this could work as the command doesn't fire any warning or error message. But it doesn't set env variable as well. So I decide to fix it. Is there anything I didn't know about the command?