### PR TITLE
Pagefind docs patch

### DIFF
--- a/plugins/pagefind.md
+++ b/plugins/pagefind.md
@@ -122,7 +122,6 @@ const site = lume();
 site.use(pagefind({
   indexing: {
     rootSelector: "html",
-    forceLanguage: false,
     verbose: false,
   },
 }));

--- a/plugins/pagefind.md
+++ b/plugins/pagefind.md
@@ -122,7 +122,6 @@ const site = lume();
 site.use(pagefind({
   indexing: {
     rootSelector: "html",
-    glob: "**/*.html",
     forceLanguage: false,
     verbose: false,
   },
@@ -130,6 +129,10 @@ site.use(pagefind({
 
 export default site;
 ```
+
+We can set explicit content indexing by adding the [`data-pagefind-body`](https://pagefind.app/docs/indexing/#removing-pages-from-pagefinds-index) attribute. If this attribute is present in an HTML element, only content inside that elemement is indexed. Anything else without this attribute will not be indexed. As such, the best way to remove pages is by adding `data-pagefind-body` to the wrapper element of the content you would like to index.
+
+Alternatively, you can selectively ignore content by setting the [`data-pagefind-ignore`](https://pagefind.app/docs/indexing/#removing-individual-elements-from-the-index) attribute on a HTML element. And `data-pagefind-ignore="all"` to also ignore its children.
 
 See the [Pagefind indexing docs](https://pagefind.app/docs/indexing/) for more
 info. {.tip}


### PR DESCRIPTION
Current documentation of pagefind shows a `glob` options to selectively include files for the creation of the index. As of Lume 1.19 this is not actually available in Lume.

At the same time, the indexing option `forceLanguage` expects an ISO 639-1 code, such as en or pt rather than a boolean value.

This update to the docs aims to remove that incorrect reference to `glob` and to propose native ways in pagefind to selectively include and exclude content in the indexing process. Apart of that, it corrects the example `forceLanguage` setting.
