### PR TITLE
fix: metas plugin typos

### DIFF
--- a/plugins/metas.md
+++ b/plugins/metas.md
@@ -106,8 +106,6 @@ to:
 </html>
 ```
 
-</lume-code>
-
 ## Field aliases
 
 Field aliases allow to use an existing value in the metas. Aliases start with

--- a/plugins/metas.md
+++ b/plugins/metas.md
@@ -84,7 +84,7 @@ to:
 
 ```html
 <html>
-  <header>
+  <head>
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Oscar's blog">
     <meta property="og:locale" content="en">
@@ -99,7 +99,7 @@ to:
     <meta itemprop="image" content="http://example.com/hello-world.png">
     <meta name="description" content="My first post">
     <meta name="generator" content="Lume v1.10.1">
-  </header>
+  </head>
   <body>
     <p>This is my first post</p>
   </body>


### PR DESCRIPTION
I fixed a typo where the docs showed an example output of the metas plugin, and for some reason the docs incorrectly said that the `<meta>` tags are inserted into a `<header>` element instead of a `<head>` element. This was probably just a typo as the two elements have very similar names.

I also deleted an non-opened `</lume-code>` component (it is never opened, only closed) as it was left like that since the page was originally committed and it somehow hasn't impacted rendering. It was right after the code block with the typo, so I'm assuming at some point it was supposed to be wrapped, but never was.