### PR TITLE
make filtering correct for Vento on the plugins page

### DIFF
--- a/plugins/vento.md
+++ b/plugins/vento.md
@@ -2,7 +2,7 @@
 title: Vento
 description: Use the Vento template engine to create pages and layouts.
 mod: plugins/vento.ts
-enabled: false
+enabled: true
 tags:
   - template_engine
 ---


### PR DESCRIPTION
https://lume.land/plugins/?status=all&template_engine=on

I think Vento is now installed by default. This fix will make this clear on the Plugins page.