### PR TITLE
Update installation.md

### DIFF
--- a/docs/overview/installation.md
+++ b/docs/overview/installation.md
@@ -115,7 +115,7 @@ to define this variable:
 ```json
 {
   "tasks": {
-    "lume": "echo \"import 'lume/cli.ts'\" | DENO_DIR=_vendor deno run --unstable -A -",
+    "lume": "echo \"import 'lume/cli.ts'\" | DENO_DIR=_vendor deno run -A -",
     "build": "deno task lume",
     "serve": "deno task lume -s"
   }


### PR DESCRIPTION
Removed --unstable flag to get rid of the following warning: 

```

   Task lume echo "import 'lume/cli.ts'" | DENO_DIR=_vendor deno run --unstable -A - "-s"
   ⚠️  The `--unstable` flag is deprecated and will be removed in Deno 2.0. Use granular `--unstable-*` flags instead.
   Learn more at: https://docs.deno.com/runtime/manual/tools/unstable_flags
```