### PR TITLE
Add `--allow-read` argument to CLI install instructions

### DIFF
--- a/docs/overview/installation.md
+++ b/docs/overview/installation.md
@@ -82,7 +82,7 @@ all the time, you can install the [Lume CLI](https://github.com/lumeland/cli)
 script with:
 
 ```sh
-deno install --allow-run --allow-read --name lume --force --reload https://deno.land/x/lume_cli/mod.ts
+deno install --allow-run --allow-env --allow-read --name lume --force --reload https://deno.land/x/lume_cli/mod.ts
 ```
 
 This creates the `lume` command:

--- a/docs/overview/installation.md
+++ b/docs/overview/installation.md
@@ -82,7 +82,7 @@ all the time, you can install the [Lume CLI](https://github.com/lumeland/cli)
 script with:
 
 ```sh
-deno install --allow-run --name lume --force --reload https://deno.land/x/lume_cli/mod.ts
+deno install --allow-run --allow-read --name lume --force --reload https://deno.land/x/lume_cli/mod.ts
 ```
 
 This creates the `lume` command:


### PR DESCRIPTION
`Deno.execPath()` as used in the more recent lume-cli scripts needs read access. 
Otherwise, you get a nasty warning on every invocation:

```
lume -h
┌ ⚠️  Deno requests read access to <exec_path>.
├ Requested by `Deno.execPath()` API.
├ Run again with --allow-read to bypass this prompt.
└ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all read permissions)
```