### PR TITLE
fix(docs): use the correct env var to show drafts page

### DIFF
--- a/docs/advanced/the-data-model.md
+++ b/docs/advanced/the-data-model.md
@@ -330,7 +330,7 @@ basename `string`
 : Normalized by Lume automatically. Used to assign tags or to pages.
 
 [draft](../creating-pages/page-data.md#tags) `boolean`
-: If it's `true`, the page will be ignored. Use the env variable `LUME_DRAFT=true` to show draft pages.
+: If it's `true`, the page will be ignored. Use the env variable `LUME_DRAFTS=true` to show draft pages.
 
 [renderOrder](../core/render-order.md) `number`
 : To configure the rendering order of a page.

--- a/docs/creating-pages/page-data.md
+++ b/docs/creating-pages/page-data.md
@@ -87,7 +87,7 @@ values are:
 ### draft
 
 The draft variable mark this page as draft, which means it will ignored unless
-the environment variable `LUME_DRAFT` is defined as `"true"`.
+the environment variable `LUME_DRAFTS` is defined as `"true"`.
 
 ### layout
 


### PR DESCRIPTION
Hello,

**What**:  In the Lume doc, the env variable mentioned in [page-data](https://lume.land/docs/creating-pages/page-data/) and [data model](https://lume.land/docs/advanced/the-data-model/) to show draft page is `LUME_DRAFT` instead of `LUME_DRAFTS`. So I fixed the documentation to represent the correct value.

**Why**: There is a typo, `LUME_DRAFTS` is the correct env variable

Thanks 🙏 