### PR TITLE
fix(doc): lume_shikiji renamed to lume_shiki

### DIFF
--- a/plugins/index.yml
+++ b/plugins/index.yml
@@ -38,9 +38,9 @@ plugins:
     description: Inclusive Language plugin for Lume 
     url: https://deno.land/x/lume_plugin_inclusive_language
 
-  - title: Shikiji
-    description: Plugin to use the Shikiji library for syntax highlight.
-    url: https://deno.land/x/lume_shikiji@0.0.1
+  - title: Shiki
+    description: Plugin to use the Shiki library for syntax highlight.
+    url: https://deno.land/x/lume_shiki
 
   - title: Fluent for Lume
     description: A Fluent wrapper to help you easily build multilingual site with Lume 


### PR DESCRIPTION
Hola 👋 

**What**: Renamed `Shikiji` into `Shiki`

**Why**: Shikiji [has merged back](https://github.com/shikijs/shiki/pull/557) to Shiki. To be consistent, `lume_shikiji` has been renamed to `lume_shiki`.

Thanks