### PR TITLE
doc: link to a page by lang

### DIFF
--- a/plugins/multilanguage.md
+++ b/plugins/multilanguage.md
@@ -163,6 +163,34 @@ This code outputs something like:
 </ul>
 ```
 
+### Link to a page in current language
+
+The easiest way to get the URL of a specific page in the current language is to use the [tags](../docs/creating-pages/tags.md) and [search.page()](../plugins/search.md#search-one-page) using a unique tag with current lang as a filter.
+
+<lume-code>
+
+```vento{title="index.vto"}
+---
+tags: ['home']
+---
+
+{{ set about = search.page('about lang=' + lang) }}
+
+<a href="{{ about.url }}">About</a> <!-- This will always output the URL translated in the current lang -->
+
+```
+
+```vento{title="about.vto"}
+---
+tags: ['about']
+---
+
+<p>This is an About page</p>
+```
+
+</lume-code>
+
+
 ### Sitemap
 
 The [Sitemap plugin](./sitemap.md) is compatible with this plugin, so the
@@ -315,6 +343,8 @@ es:
 ```
 
 </lume-code>
+
+This only works at page level.{.tip}
 
 ## Multilanguage + pagination
 

--- a/plugins/multilanguage.md
+++ b/plugins/multilanguage.md
@@ -165,24 +165,23 @@ This code outputs something like:
 
 ### Link to a page in current language
 
-The easiest way to get the URL of a specific page in the current language is to use the [tags](../docs/creating-pages/tags.md) and [search.page()](../plugins/search.md#search-one-page) using a unique tag with current lang as a filter.
+The easiest way to get the URL of a specific page in the current language is to use the [id](#create-pages-in-multiple-languages) and [search.page()](../plugins/search.md#search-one-page) with current lang as a filter.
 
 <lume-code>
 
 ```vento{title="index.vto"}
 ---
-tags: ['home']
+id: home
 ---
 
 {{ set about = search.page('id=about lang=' + lang) }}
 
 <a href="{{ about.url }}">About</a> <!-- This will always output the URL translated in the current lang -->
-
 ```
 
 ```vento{title="about.vto"}
 ---
-tags: ['about']
+id: about
 ---
 
 <p>This is an About page</p>

--- a/plugins/multilanguage.md
+++ b/plugins/multilanguage.md
@@ -174,7 +174,7 @@ The easiest way to get the URL of a specific page in the current language is to 
 tags: ['home']
 ---
 
-{{ set about = search.page('about lang=' + lang) }}
+{{ set about = search.page('id=about lang=' + lang) }}
 
 <a href="{{ about.url }}">About</a> <!-- This will always output the URL translated in the current lang -->
 


### PR DESCRIPTION
Hi 👋, 

I've been using the multilanguage today and found this way to link to a page in the current language:

```vto
{{ set about = search.page('about lang=' + lang) }}

<a href="{{ about.url }}">About</a> <!-- This will always output the URL translated in the current lang -->
```

Thinks it would be nice to add in the doc.
*(+ a small information about the translated data only working at page level).*

Thank you!