### PR TITLE
Docs typo fix: Correcting the closing tag in `if` statement in example

### DIFF
--- a/plugins/search.md
+++ b/plugins/search.md
@@ -195,13 +195,13 @@ current page. Let's see an example:
 
 {{ if post }}
   <a href="{{ post.url }}" rel="prev">← {{ post.title }}</a>
-{{ /for }}
+{{ /if }}
 
 {{ set post = search.nextPage(url, "html") }}
 
 {{ if post }}
   <a href="{{ post.url }}" rel="next">{{ post.title }} →</a>
-{{ /for }}
+{{ /if }}
 ```
 
 ## Get all values of a key


### PR DESCRIPTION
The `if` statements in this example have mismatched closing tags. 

Updating the closing tags from `{{ /for}}` to `{{ /if }}` so that they correctly close the `if` statements, and the example works as expected.