### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/advanced/the-data-model.md
+++ b/docs/advanced/the-data-model.md
@@ -154,7 +154,7 @@ This is converted to:
 {
   url: "/posts/hello-world/",
   date: Date("2023-11-30 00:00:00"),
-  basename: "hello-word",
+  basename: "hello-world",
   content: "Hello **world**"
 }
 ```
@@ -178,7 +178,7 @@ Is converted to:
 {
   url: "/posts/hello-world/",
   date: Date("2023-11-30 00:00:00"),
-  basename: "hello-word",
+  basename: "hello-world",
   content: "Hello **world**",
   search: Searcher(),
   paginate: Paginate(),

--- a/docs/creating-pages/urls.md
+++ b/docs/creating-pages/urls.md
@@ -154,7 +154,7 @@ final URL:
 basename: ""
 ```
 
-The final URL of the file is now `/blog/hello-word/`, the `/post/` part was
+The final URL of the file is now `/blog/hello-world/`, the `/post/` part was
 removed. You can also remove the previous folder with:
 
 ```yml


### PR DESCRIPTION
A couple of instances of `hello-world` snuck through as `hello-word`. 