### PR TITLE
fixed the-data-model not been updated to Lume 2

### DIFF
--- a/docs/advanced/the-data-model.md
+++ b/docs/advanced/the-data-model.md
@@ -258,9 +258,11 @@ and you can access the data of the page with the `Page.data` property.
 ```js
 // _config.js
 
-site.preprocess([".html"], (page) => {
-  const data = page.data; // Get the Data object
-  data.title += " - My site name"; // Modify the title variable
+site.preprocess([".html"], (pages) => {
+  for (const page of pages) {
+    const data = page.data; // Get the Data object
+    data.title += " - My site name"; // Modify the title variable
+  }
 });
 ```
 


### PR DESCRIPTION
The change was copied from [docs/core/processors.md](https://github.com/lumeland/lume.land/blob/edabb6e6fe50f0737f10dd847692495c84a7dbfd/docs/core/processors.md).

Supposedly this change is mistakenly missing from edabb6e6.