### PR TITLE
fix: Fixed terminal block styling issues

### DIFF
--- a/_includes/styles/components/terminal.css
+++ b/_includes/styles/components/terminal.css
@@ -10,6 +10,7 @@
     box-shadow: 0 0 0 1px rgba(255, 255, 255, .1);
     position: relative;
     overflow: hidden;
+    margin: 1px 0 1px 1px;
 
     &::after {
       content: "";
@@ -89,6 +90,7 @@
   display: flex;
   align-items: center;
   transition: background var(--animation-duration);
+  z-index: 2;
 
   & svg,
   & path {

--- a/docs/core/archetypes.md
+++ b/docs/core/archetypes.md
@@ -1,6 +1,6 @@
 ---
 title: Archetypes
-description: Scripts to create a templates for new content. 
+description: Scripts to create a templates for new content.
 order: 13
 ---
 


### PR DESCRIPTION
Fixed a sizing issue with `terminal` css 

Before:

![image](https://github.com/user-attachments/assets/3d92721f-16b2-43ac-a407-10301d980d3e)

After:

![image](https://github.com/user-attachments/assets/7b53fcf9-ce02-4a4c-903a-47f72930d14f)
