### PR TITLE
fix: typo and javascript syntax in remark.md

### DIFF
--- a/plugins/remark.md
+++ b/plugins/remark.md
@@ -40,7 +40,7 @@ import rehypeRemoveComments from 'npm:rehype-remove-comments@5';
 const site = lume();
 
 site.use(remark({
-  remarkPlugins: [allyEmoji]
+  remarkPlugins: [a11yEmoji],
   rehypePlugins: [rehypeRemoveComments]
 }));
 


### PR DESCRIPTION
renamed `ally` to `a11y` to match the import and added missing comma.