### PR TITLE
Add canonical url example to url.md

### DIFF
--- a/plugins/url.md
+++ b/plugins/url.md
@@ -73,3 +73,11 @@ text: 'Go to <a href="/">Homepage</a>'
 ---
 <div>{{ text | htmlUrl | safe }}</div>
 ```
+
+## Example
+
+As a good SEO practice, you can consider adding a canonical URL to your `<head>` section (e.g. in a `base.vto` template) like this: 
+
+```vento
+<link rel="canonical" href="{{ url |> url(true) }}">
+```


### PR DESCRIPTION
Apparently having a canonical url in your `<head>` is considered quite important from an SEO standpoint, and people asked about it on the Discord, so I added an example.