### PR TITLE
Correct location value in cheatsheet, removing port from localhost

### DIFF
--- a/docs/advanced/cheatsheet.md
+++ b/docs/advanced/cheatsheet.md
@@ -24,7 +24,7 @@ const site = lume(
     includes: "_includes",
 
     /** The site location (used to generate final urls) */
-    location: new URL("https://localhost:3000"),
+    location: new URL("http://localhost"),
 
     /** Set true to generate pretty urls (`/about-me/`) */
     prettyUrls: true,


### PR DESCRIPTION
Actual value of `location` in v2.5.1: `http://localhost`
https://github.com/lumeland/lume/blob/v2.5.1/cli.ts#L64C17-L64C33 
same in v3-dev: https://github.com/lumeland/lume/blob/v3-dev/cli.ts#L64

So `https` should become `http` and port (`:3000`) here is extraneous in the cheatsheet: https://github.com/lumeland/lume.land/blob/bc3bdd7578c1ca050d45813178824792892c2f3a/docs/advanced/cheatsheet.md#L27