### PR TITLE
docs: update all pages under `/docs` to clean up their grammar

### DIFF
--- a/docs/advanced/cheatsheet.md
+++ b/docs/advanced/cheatsheet.md
@@ -5,22 +5,22 @@ description: All configuration options in a simple page
 
 ## Lume instantiation
 
-These are all available options (and the default values) when creating a new
-site:
+These are all the available options (and their default values) when creating a
+new site:
 
 ```js
 const site = lume(
   {
-    /** The path of the site source */
+    /** Where the site's source is stored */
     src: "./",
 
-    /** The path of the build destination */
+    /** Where the built site will go */
     dest: "./_site",
 
     /** Whether the destination folder (defined in `dest`) should be emptied before the build */
     emptyDest: true,
 
-    /** The default includes path */
+    /** The default includes path, relative to the `src` folder */
     includes: "_includes",
 
     /** The site location (used to generate final urls) */
@@ -29,24 +29,24 @@ const site = lume(
     /** Set true to generate pretty urls (`/about-me/`) */
     prettyUrls: true,
 
-    /** The local server options */
+    /** Local server options(when using `lume --serve`) */
     server: {
       /** The port to listen on */
       port: 3000,
 
-      /** To open the server in a browser */
+      /** Open the server in a browser after starting the server */
       open: false,
 
-      /** The file to serve on 404 error */
+      /** The file to serve when getting a 404 error */
       page404: "/404.html",
 
-      /** Optional middlewares for the server */
+      /** Optional middleware for the server */
       middlewares: [];
     },
 
-    /** The local watcher options */
+    /** Local file watcher options */
     watcher: {
-      /** Paths to ignore by the watcher */
+      /** Paths to ignore */
       ignore: [
         "/.git",
         (path) => path.endsWith("/.DS_Store"),
@@ -56,41 +56,41 @@ const site = lume(
       debounce: 100,
     },
 
-    /** The components options */
+    /** Component options */
     components: {
-      /** The variable name used to access to the components */
+      /** The variable name used to access the components */
       variable: "comp",
 
-      /** The name of the file to save the components css code */
+      /** The name of the file to save component css code to */
       cssFile: "/components.css",
 
-      /** The name of the file to save the components javascript code */
+      /** The name of the file to save component javascript code to */
       jsFile: "/components.js",
     }
   },
   {
-    /** Options for url plugin loaded by default */
+    /** Options for the url plugin, which is loaded by default */
     url: undefined,
 
-    /** Options for json plugin loaded by default */
+    /** Options for the json plugin, which is loaded by default */
     json: undefined,
 
-    /** Options for markdown plugin loaded by default */
+    /** Options for the markdown plugin, which is loaded by default */
     markdown: undefined,
 
-    /** Options for modules plugin loaded by default */
+    /** Options for the modules plugin, which is loaded by default */
     modules: undefined,
 
-    /** Options for nunjucks plugin loaded by default */
+    /** Options for the nunjucks plugin, which is loaded by default */
     nunjucks: undefined,
 
-    /** Options for search plugin loaded by default */
+    /** Options for the search plugin, which is loaded by default */
     search: undefined,
 
-    /** Options for paginate plugin loaded by default */
+    /** Options for the paginate plugin, which is loaded by default */
     paginate: undefined,
 
-    /** Options for yaml plugin loaded by default */
+    /** Options for the yaml plugin, which is loaded by default */
     yaml: undefined,
   }
 )
@@ -98,7 +98,7 @@ const site = lume(
 
 ## Lume site configuration
 
-All available functions to configure the site build:
+All available functions for configuring the site build:
 
 ```js
 /** Register an event listener */
@@ -141,7 +141,7 @@ site.page(pageData, scope = "/");
 /** Register a component */
 site.component(context, component, scope = "/");
 
-/** Configure the strategy to merge a key in the data cascade */
+/** Configure the strategy for merging a specfic key in the data cascade */
 site.mergeKey(key, merge, scope = "/");
 
 /** Copy a static file/folder */
@@ -153,7 +153,7 @@ site.copyRemainingFiles(filter);
 /** Ignore files or folder */
 site.ignore(...paths);
 
-/** Configure independent scopes to optimize the build after updating */
+/** Configure independent scopes to optimize builds when source files update */
 site.scopedUpdates(...scopes);
 
 /** Define a remote file */

--- a/docs/advanced/deployment.md
+++ b/docs/advanced/deployment.md
@@ -21,7 +21,7 @@ creating a deno task in the `deno.json` file:
 }
 ```
 
-In addition to the regular Lume task, we have added a new task, named **deploy**
+In addition to the regular Lume tasks, we have added a new task named **deploy**
 that executes two commands: It builds the site and uploads it to the server.
 Now, to build and deploy your site, just run:
 
@@ -32,7 +32,7 @@ deno task deploy
 ## GitHub Pages
 
 To deploy a Lume site using [GitHub Pages](https://pages.github.com/), go to
-Settings > Pages in your repo, configure the source to use GitHub Actions and
+Settings > Pages in your repo, configure the source to use GitHub Actions, then
 create the following workflow:
 
 ```yml
@@ -77,7 +77,7 @@ jobs:
 ## GitLab Pages
 
 To deploy a Lume site using
-[GitLab Pages](https://docs.gitlab.com/ee/user/project/pages/), set a CI/CD
+[GitLab Pages](https://docs.gitlab.com/ee/user/project/pages/), create a CI/CD
 configuration with the following code:
 
 <lume-code>
@@ -107,9 +107,9 @@ argument is not needed if you have defined the
 ## Deno Deploy
 
 [Deno Deploy](https://deno.com/deploy) is a distributed deploy system provided
-by Deno with support for static files. It requires having your repo in GitHub.
+by Deno with support for static files. It requires having your repo on GitHub.
 
-- Sign up in Deno Deploy and create a new project.
+- Sign up to Deno Deploy and create a new project.
 - Configure the Git integration to use the **GitHub Actions** deployment mode.
 - In your repository, you need an entrypoint file to serve the files. Create the
   file `serve.ts` with the following code:
@@ -164,14 +164,14 @@ jobs:
 
 ## Netlify
 
-According the
+According to the
 ["Available software at build time"](https://docs.netlify.com/configure-builds/available-software-at-build-time/#tools)
 page at Netlify's documentation website, Deno is one of several supported
-runtimes at build time. In order to build your project, you'll need to tell
+runtimes when building. In order to build your project, you'll need to tell
 Netlify which command to run at build time, which is `deno task build` in this
 case.
 
-Create `netlify.toml` file in your repository with the following code:
+Create a `netlify.toml` file in your repository with the following code:
 
 <lume-code>
 
@@ -194,7 +194,7 @@ Create `netlify.toml` file in your repository with the following code:
 
 ## Vercel
 
-[Vercel](https://vercel.com/), doesn't have Deno available by default so the
+[Vercel](https://vercel.com/), doesn't have Deno available by default, so the
 build command must install it.
 
 ```sh
@@ -246,7 +246,7 @@ Configure the output directory to `_site`.
 
 ## AWS Amplify
 
-To deploy your Lume site with [AWS Amplify](https://aws.amazon.com/amplify/)
+To deploy your Lume site with [AWS Amplify](https://aws.amazon.com/amplify/),
 create a `amplify.yml` file with the following code:
 
 <lume-code>
@@ -269,16 +269,16 @@ frontend:
 
 </lume-code>
 
-Remember to ignore `amplify.yml` file in the Lume `_config.ts` file. If you
+Remember to ignore the `amplify.yml` file in the Lume `_config.ts` file. If you
 don't want to create this file in your repository, you can configure it in the
 AWS control panel.
 
 ## Kinsta
 
-[Kinsta](https://kinsta.com/) is a hosting service that allows to host
-[up to 100 static sites for free](https://kinsta.com/static-site-hosting/). Due
-Kinsta only has support for Node, to host a Lume site you need to create the
-following `package.json` file:
+[Kinsta](https://kinsta.com/) is a hosting service that allows hosting
+[up to 100 static sites for free](https://kinsta.com/static-site-hosting/).
+Because Kinsta only has support for NodeJS, to host a Lume site you need to
+create the following `package.json` file:
 
 ```json
 {
@@ -291,7 +291,7 @@ following `package.json` file:
 }
 ```
 
-In the project settings, configure the build command to `npm run build` and the
+In the project settings, set the build command to `npm run build` and the
 publish directory to `_site`.
 
 Kinsta provides [this nice template](https://github.com/kinsta/hello-world-lume)
@@ -300,6 +300,6 @@ that you can use.
 ## Surge
 
 [Surge](https://surge.sh/) is a CLI-based static web publishing host with
-unlimited sites and custom domain. To upload your site on Surge, you need to
-install first the CLI tool with `npm install --global surge`. Then, in the
-`_dest` directory, run `surge` to login/register and upload the site.
+unlimited sites and custom domain support. To upload your site on Surge, you
+need to first install the CLI tool with `npm install --global surge`. Then, in
+the `_dest` directory, run `surge` to login/register and upload the site.

--- a/docs/advanced/migrate-to-lume2.md
+++ b/docs/advanced/migrate-to-lume2.md
@@ -4,7 +4,7 @@ description: Guide to migrate your project from Lume 1 to Lume 2
 ---
 
 This page is a brief to-do list of the main changes to make in order to migrate
-a site from Lume 1 to Lume 2. You have a more detailed description
+a site from Lume 1 to Lume 2. There is a more detailed description
 [in the announcement post](https://lume.land/blog/posts/lume-2/).
 
 ## Change your (pre)processors
@@ -34,7 +34,7 @@ site.process([".html"], fn);
 
 ## Change `.page.*` pages
 
-The subextension `.tmpl` for TypeScript/JavaScript pages was changed to `.page`
+The subextension `.tmpl` for TypeScript/JavaScript pages was changed to `.page`,
 and it's no longer required for layouts. This structure in Lume 1:
 
 ```txt
@@ -44,7 +44,7 @@ _data.js
 index.tmpl.js
 ```
 
-In Lume 2 becomes to:
+Becomes this layout in Lume 2:
 
 ```txt
 _includes/layout.js
@@ -54,8 +54,8 @@ index.page.js
 ```
 
 [This is a simple script](https://gist.github.com/oscarotero/c6404f36530cf989ec1ba65b75d41e9c)
-to rename the files automatically. To keep using `.page` as the subextension,
-you can edit the option `pageSubExtension` to the `module` and `json` plugins:
+to rename your files automatically. To keep using `.page` as the subextension,
+you can edit the option `pageSubExtension` in the `module` and `json` plugins:
 
 ```js
 import lume from "lume/mod.ts";
@@ -68,13 +68,12 @@ const site = lume({}, { modules, json });
 export default lume;
 ```
 
-## Changes in URL generation:
+## Changes in URL generation
 
 ### The `url` function
 
-If you're generating the url of the pages with the `url()` function, keep in
-mind that the property `page.src.slug` was removed. Use `page.data.basename`
-instead.
+If you're generating the url of pages with the `url()` function, keep in mind
+that the `page.src.slug` property was removed. Use `page.data.basename` instead.
 
 ```js
 // Lume 1
@@ -85,7 +84,7 @@ export const url = (page) => `/articles/${page.data.basename}/`;
 ```
 
 In Lume 2, the page passed to the function has already the default URL applied,
-which is easier to make small tweaks:
+which makes it easier to do small tweaks:
 
 ```js
 // Only in Lume 2:
@@ -183,9 +182,9 @@ HTML attribute name has changed to `transform-images`:
 
 ## Nunjucks plugin
 
-Lume 1.x enabled the nunjucks plugin by default. It is an optional plugin in
-Lume 2.x If you're using Nunjucks templates, import the plugin in your
-_config.ts file:
+Lume 1.x enabled the nunjucks plugin by default. However, it is an optional
+plugin in Lume 2.x, If you're using Nunjucks templates, import the plugin in
+your _config.ts file:
 
 ```ts
 import lume from "lume/mod.ts";
@@ -204,7 +203,7 @@ the import in your _config file.
 
 ## Searching
 
-The functions `search.page()` and `search.pages()` returns the data object
+The functions `search.page()` and `search.pages()` return the data object
 instead of the page instance:
 
 ```tsx
@@ -219,7 +218,7 @@ for (const data of search.pages("type=article")) {
 }
 ```
 
-The function `search.tags()` was removed. Use `search.values`:
+The function `search.tags()` was removed. Use `search.values()` instead:
 
 ```ts
 // Lume 1
@@ -229,7 +228,7 @@ const tags = search.tags();
 const tags = search.values("tags");
 ```
 
-The filter `data` was removed:
+The `data` filter was removed:
 
 ```html
 <!-- Lume 1 -->
@@ -241,7 +240,7 @@ The filter `data` was removed:
 
 ## JSX plugin
 
-The global object `window.React` was removed. If you have problems compiling
+The `window.React` global object was removed. If you have problems compiling
 your JSX pages, configure the JSX transformer in the `deno.json` file:
 
 ```json
@@ -259,7 +258,7 @@ your JSX pages, configure the JSX transformer in the `deno.json` file:
 ## Slugify URLs plugin
 
 If you're using the `slugify_urls` plugin, it also slugifies files copied with
-`site.copy()`. To disable it:
+`site.copy()`. To disable this behavior:
 
 ```js
 site.use(slugifyUrls({
@@ -269,7 +268,7 @@ site.use(slugifyUrls({
 
 ## Netlify CMS plugin
 
-This plugin was renamed to `decap_cms`. And the `netlifyIdentity` option was
+This plugin was renamed to `decap_cms`, and the `netlifyIdentity` option was
 renamed to `identity`:
 
 ```ts
@@ -297,7 +296,7 @@ site.use(unoCSS());
 ```
 
 > The UnoCSS plugin is not a 1:1 substitute of windiCSS. There's a comparison
-> [in this link](https://unocss.dev/presets/wind#differences-from-windi-css)
+> [here](https://unocss.dev/presets/wind#differences-from-windi-css).
 
 ## Feed plugin
 
@@ -356,9 +355,9 @@ es:
 
 ## Plugins options
 
-The option `keepDefaultPlugins` was renamed to `useDefaultPlugins` that is
-`true` by default. This affects to the plugins `postcss`, `markdown`, `mdx`,
-`remark`.
+The option `keepDefaultPlugins` was renamed to `useDefaultPlugins`, which is set
+to `true` by default. This affects the `postcss`, `markdown`, `mdx`, and
+`remark` plugins.
 
 ```ts
 // Lume 1

--- a/docs/advanced/order-of-operations.md
+++ b/docs/advanced/order-of-operations.md
@@ -6,52 +6,52 @@ description: What does Lume do to build your site?
 This is a high-level description of how Lume builds your site. When you run
 `lume`, the following operations are executed in this order:
 
-1. Dispatch the [event](../core/events.md) `beforeBuild`.
+1. Dispatch the `beforeBuild` [event](../core/events.md).
 2. Ensure the `dest` folder is empty (unless
    [`emptyDest` is disabled](../configuration/config-file.md#emptydest)).
 3. Walk the `src` folder recursively and build a tree with all files and
-   folders. The files [loaded remotely](../core/remote-files.md) are also added.
-4. Dispatch the [event](../core/events.md) `afterLoad`.
+   folders. Any [remote files](../core/remote-files.md) are added here.
+4. Dispatch the `afterLoad` [event](../core/events.md).
 5. Walk the tree recursively and load all files matching with a valid file
    extension, like `.md`, `.vto`, etc.
-   - Skip files and folders starting with `_`, `.` or ignored with
+   - Skip files and folders starting with `_`, `.`, or ignored with
      `site.ignore()`.
    - If the file
      [must be copied statically](../configuration/copy-static-files.md),
      calculate the source and destination paths.
-   - If the name of the file is `_data` or is inside a `_data` folder, is shared
-     data.
+   - If the name of the file is `_data` or is inside a `_data` folder, it is
+     shared data.
    - If the file is inside a `_components` folder, it is a component.
    - If it has a known extension, it's a page.
    - Otherwise, ignore it (or copy it if
      [`copyRemainingFiles`](../configuration/copy-static-files.md#copy-remaining-files)
      is enabled).
-6. Dispatch the [event](../core/events.md) `beforeRender`.
+6. Dispatch the `beforeRender` [event](../core/events.md).
 7. Group all pages by [`renderOrder` value](../core/render-order.md) and sort
    them.
 8. For each group of pages with the same `renderOrder`:
    - If the [page content is a generator](../core/searching.md#pagination),
      generate all the sub-pages.
    - Calculate the [final url](../creating-pages/urls.md).
-   - Run the [preprocessors](../core/processors.md#preprocess) registered.
+   - Run registered [preprocessors](../core/processors.md#preprocess).
    - Render the page using the assigned
      [template engine](../core/multiple-template-engines.md) and
      [layout](../creating-pages/layouts.md).
-9. Dispatch the [event](../core/events.md) `afterRender`.
-10. Run the [processors](../core/processors.md) registered
-11. Dispatch the [event](../core/events.md) `beforeSave`.
-12. Save all pages to `dest` folder.
-13. Dispatch the [event](../core/events.md) `afterBuild`.
+9. Dispatch the `afterRender` [event](../core/events.md).
+10. Run registered [processors](../core/processors.md).
+11. Dispatch the `beforeSave` [event](../core/events.md).
+12. Save all pages to the `dest` folder.
+13. Dispatch the `afterBuild` [event](../core/events.md).
 
 ## Watch mode
 
 In watch mode (with `lume --serve` or `lume --watch`), the first build is
-exactly the same, but the successive changes have some differences:
+exactly the same, but any following changes have some differences:
 
 - The `dest` folder is not emptied.
-- Only the files with changes are reloaded.
-- Steps 4 to 10 are exactly the same. All pages (not only the modified ones) are
-  re-rendered. This is because a change in one file can affect many pages, so we
-  have to render all pages again. See
-  [scoped updated](../core/scoped-updates.md) to learn how to configure this.
-- Only the pages that have changed their content are saved in `dest`.
+- Only files with changes are reloaded.
+- Steps 4 to 10 are exactly the same. All pages (not just the modified ones) are
+  re-rendered, because a change in one file can affect many pages, so we have to
+  render all pages again. See [scoped updates](../core/scoped-updates.md) to
+  learn how to configure this.
+- All pages that have changed are saved to `dest`.

--- a/docs/advanced/permissions.md
+++ b/docs/advanced/permissions.md
@@ -3,10 +3,9 @@ title: Permissions
 description: Configure the Deno's permissions for Lume
 ---
 
-Deno has a permission system that allows configuring the access to different
-APIs like environment variables, filesystem reads or writes, net access, etc.
-See the
-[Deno's permissions manual](https://docs.deno.com/runtime/manual/basics/permissions/)
+Deno has a permission system that allows configuring access to different APIs
+like environment variables, filesystem reads or writes, net access, etc. See the
+[Deno permissions manual](https://docs.deno.com/runtime/manual/basics/permissions/)
 for more info.
 
 Lume is executed by default with the `-A` flag (or `--allow-all`), allowing all
@@ -24,9 +23,9 @@ script to run Lume:
 }
 ```
 
-This scripts echoes the `import 'lume/cli.ts'` code and then executes it. This
-allows resolving the `lume/cli.ts` module with the import map, so it's possible
-to update Lume just by editing the `import_map.json` file.
+This scripts echoes `import 'lume/cli.ts'` and then executes it. This allows
+resolving the `lume/cli.ts` module with the import map, so it's possible to
+update Lume just by editing the `import_map.json` file.
 
 If you are concerned about the permissions granted to Lume and want to customize
 them, it's possible by replacing `-A` flag with your desired permission flags in

--- a/docs/advanced/plugins.md
+++ b/docs/advanced/plugins.md
@@ -1,12 +1,12 @@
 ---
 title: Creating plugins
-description: Guide to create your own plugins to extend Lume
+description: Guide to creating your own plugins for Lume
 ---
 
-Lume can be extended easily by adding more [loaders](../core/loaders.md),
-[engines](../core/loaders.md#template-engines),
-[processors](../core/processors.md) etc. Plugins provide an easy interface to
-extend Lume without writing too much code in the `_config.ts` file.
+Lume can be easily extended by adding more [loaders](../core/loaders.md),
+[engines](../core/loaders.md#template-engines), or
+[processors](../core/processors.md). Plugins provide an easy interface to extend
+Lume without writing too much code in the `_config.ts` file.
 
 A plugin is just a function that receives a lume instance in the first argument,
 in order to configure and register new elements to it.
@@ -63,7 +63,7 @@ export default function (options: Options) {
 }
 ```
 
-And now, we can use it in the `_config.ts` file in this way:
+And now, we can use it in the `_config.ts` file like this:
 
 ```ts
 import lume from "lume/mod.ts";
@@ -79,17 +79,17 @@ export default site;
 ```
 
 Plugins can't do anything that you couldn't do in the `_config.ts` file, but
-they provide a better interface to organize and reuse your code. And better:
-share it with others.
+they provide a better interface to organize, reuse, and even share your code
+with others.
 
-Take a look to the
-[repository of Lume plugins](https://github.com/lumeland/lume/tree/master/plugins)
+Take a look at the
+[Lume plugins repository](https://github.com/lumeland/lume/tree/master/plugins)
 for more advanced examples.
 
 ## Hooks
 
 Some plugins expose _hooks_ that can be invoked by other plugins or in the
-`_config.ts` file. A hook is only a function that can do arbitrary things, like
+`_config.ts` file. A hook is a function that can do arbitrary things, like
 changing a configuration of a plugin. Hooks are stored in `site.hooks`. Let's
 create a hook in our `css_banner` plugin to change the message:
 
@@ -119,7 +119,7 @@ export default function (options: Options) {
 }
 ```
 
-Now the message can be changed after the plugin installation:
+Now the message can be changed after plugin installation:
 
 ```ts
 import lume from "lume/mod.ts";
@@ -171,8 +171,8 @@ export default site;
 ## Publishing plugins
 
 If you created a plugin and want to let other people use it, it's
-straightforward thanks to HTTP imports and native TypeScript support by Deno.
-You only need to make your code accessible through an HTTP URL.
+straightforward thanks to HTTP imports and Deno's native Typescript support. You
+only need to make your code accessible over an HTTP URL.
 
 This is a list of recommendations:
 
@@ -203,5 +203,5 @@ entry in your import maps).
   and code changes made automatically by the platform that can cause unexpected
   bugs.
 
-- Once your plugin is published, please let us know!!. You can create a PR to
+- Once your plugin is published, please let us know! You can create a PR to the
   [awesome-lume repository](https://github.com/lumeland/awesome-lume).

--- a/docs/advanced/the-data-model.md
+++ b/docs/advanced/the-data-model.md
@@ -21,7 +21,7 @@ is converted to this object:
 }
 ```
 
-If the file has additional variables, like a front matter, they are added to the
+If the file has additional variables, like front matter, they are added to the
 `Data` object:
 
 ```md
@@ -42,9 +42,9 @@ Now the title is added to the page data:
 ```
 
 This model is the same for any file that Lume can load. Even for images: let's
-say you have the [transform_images](../../plugins/transform_images.md) plugin to
-load and transform the data. The file content is loaded and stored in the
-`content` variable:
+say you have the [transform_images](../../plugins/transform_images.md) plugin
+enabled to load and transform your images. The file content is loaded and stored
+in the `content` variable:
 
 ```js
 {
@@ -121,14 +121,14 @@ content below.
 
 ## Extra variables
 
-Once the file is loaded and converted to the `Data` model, Lume adds
-automatically 3 variables:
+Once the file is loaded and converted to the `Data` model, Lume automatically
+adds 3 variables:
 
-- `url`: Define the output URL of the page.
-- `date`: Define the date of the page.
-- `basename`: Define the basename of the page (only in Lume 2).
+- `url`: Defines the page's output URL.
+- `date`: Defines the page's date.
+- `basename`: Define the page's basename (only in Lume 2).
 
-You can define the `url` as an absolute or relative path or even a function
+You can define the `url` as an absolute or relative path, or even a function
 ([see URLs documentation](../creating-pages/urls.md) for more info). Lume will
 resolve this value to a string, and if the url is `false`, the page is ignored.
 
@@ -161,7 +161,7 @@ This is converted to:
 
 ## Data inheritance
 
-Once a page is loaded, converted to `Data` and the special variables `url`,
+Once a page is loaded, converted to `Data`, and the special variables `url`,
 `date` and `basename` are assigned, it's merged with other data defined in
 [`_data` files](../creating-pages/shared-data.md). Components stored in the
 `_components` folders are added to the page under the `comp` variable. Other
@@ -205,7 +205,7 @@ export default function* () {
   for (const number of numbers) {
     yield {
       url: `/page-${number}/`,
-      content: `This is the page number ${number}`,
+      content: `This is page number ${number}`,
     };
   }
 }
@@ -217,7 +217,7 @@ That generates the three following pages:
 {
   layout: "main.vto",
   url: "/page-1/",
-  content: "This is the page number 1",
+  content: "This is page number 1",
   date: Date(),
   basename: "page-1",
   search: Searcher(),
@@ -228,7 +228,7 @@ That generates the three following pages:
 {
   layout: "main.vto",
   url: "/page-2/",
-  content: "This is the page number 2",
+  content: "This is page number 2",
   date: Date(),
   basename: "page-2",
   search: Searcher(),
@@ -239,7 +239,7 @@ That generates the three following pages:
 {
   layout: "main.vto",
   url: "/page-3/",
-  content: "This is the page number 3",
+  content: "This is page number 3",
   date: Date(),
   basename: "page-3",
   search: Searcher(),
@@ -251,9 +251,9 @@ That generates the three following pages:
 ## Preprocessors
 
 If you've defined [any preprocessor](../core/processors.md#preprocess) in your
-`_config` file, it's executed at this point. Preprocessors allow modification of
-the `Data` object before rendering. The preprocessors receive the `Page`
-instance and the `Data` object is stored in the `Page.data` property.
+`_config` file, they're executed here. Preprocessors allow modification of the
+`Data` object before rendering. The preprocessors receive the `Page` instance
+and the `Data` object is stored in the `Page.data` property.
 
 ```js
 // _config.js
@@ -353,7 +353,7 @@ children `string | Uint8Array | function | object`
 : Configure how some data keys will be merged with the parent data.
 
 [onDemand](../../plugins/on_demand.md) `boolean`
-: Whether render this page on demand or not.
+: Whether to render this page on demand or not.
 
 lang `string`
 : The language of the page.

--- a/docs/configuration/config-file.md
+++ b/docs/configuration/config-file.md
@@ -79,7 +79,7 @@ be built in several steps to prevent running out of memory.
 
 This is the public URL of the site. It's useful to generate absolute URLs or fix
 the relative URLs if your site is published under a subdirectory, for example:
-`https://example.com/project-name/`. It only accepts an
+`https://example.com/project-name/`. It only accepts a
 [URL object](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL), for
 example:
 
@@ -111,12 +111,12 @@ const site = lume({
 
 ### caseSensitiveUrls
 
-Lume prevents to save two pages with the same URL. By default pages with the
-same name but different case are considered the same page, for example
-`/about-us/` and `/About-Us/`. This behavior matches with the file system of
-Windows and MacOS that are case insensitive. You can set this option to `true`
-to make it case sensitive, so both pages would be considered different. Note
-that this behavior is only compatible with Linux.
+Lume prevents saving two pages with the same URL. By default pages with the same
+name but different case are considered the same page, for example `/about-us/`
+and `/About-Us/`. This behavior matches Windows and MacOS' file systems, which
+are case insensitive. You can set this option to `true` to make it case
+sensitive, so both pages would be considered different. Note that this behavior
+is only compatible with Linux.
 
 ### includes
 

--- a/docs/configuration/copy-static-files.md
+++ b/docs/configuration/copy-static-files.md
@@ -59,7 +59,7 @@ site.ignore("/files/pictures/");
 site.copy("/files/");
 ```
 
-If you need to copy a file starting with `.` or `_`, you have to configure it
+If you need to copy a file starting with `.` or `_`, you have to add it
 explicitly:
 
 ```js
@@ -69,8 +69,8 @@ site.copy("_headers");
 
 ## Copy by file extension
 
-An additional way to select files is by extension. Use an array with the
-extensions of the files that you want to copy:
+Another way to select files is by extension. Use an array with the extensions of
+the files that you want to copy:
 
 ```js
 // Copy all image files
@@ -79,13 +79,13 @@ site.copy([".jpg", ".gif", ".png"]);
 
 This will copy all files with the extensions `.jpg`, `.gif` and `.png`, keeping
 the original file structure. For example, the file `/img/pictures/image.jpg`
-will be copied into `_site/img/pictures/image.jpg` location.
+will be copied into `_site/img/pictures/image.jpg`.
 
 ## Customize the destination
 
 For more fine-tuning of the file destination, you can provide a function in the
-second argument that accepts the original file path and must return the
-destination path:
+second argument that accepts the original file path and returns the destination
+path:
 
 ```js
 // Copy all files in the static directory but ensure they are lower case
@@ -102,10 +102,10 @@ site.copy([".jpg", ".gif", ".png"], (file) => "/img" + file);
 
 ## Copy remaining files
 
-Sometimes it's not possible to know in advance all files that must be copied,
+Sometimes it's not possible to know all files that must be copied ahead-of-time,
 because they can be stored in any folder or can have any extension. For example,
-imagine you have a website with articles, and every article is stored in it's
-folder that can contain static files of any extension:
+imagine you have a website with articles, and every article is stored in a
+folder that can contain static files with any extension:
 
 ```txt
 |_ articles/
@@ -122,9 +122,9 @@ folder that can contain static files of any extension:
 
 We cannot do `site.copy("articles")`, because the `index.md` files are inside
 these folders and wouldn't be processed (they would be treated as static files).
-We can select the files by extension with
+We could select the files by extension with
 `site.copy([".jpg", ".pdf", ".gif", ".mp4", ".zip"])` but every time a file with
-a new extension is uploaded to our site, we have to remember to update the
+a new extension is uploaded to our site, we would have to remember to update the
 `_config` file.
 
 For these use cases, there's the `copyRemainingFiles()` function that basically

--- a/docs/configuration/data.md
+++ b/docs/configuration/data.md
@@ -4,7 +4,7 @@ description: Adding global data to be used anywhere in your site
 order: 4
 ---
 
-You can set global variables to your site, accessible by all pages, layouts and
+You can set global variables in your site, accessible by all pages, layouts and
 components. For example:
 
 ```js
@@ -38,12 +38,13 @@ export default function ({ myNumber, randomNumber }) {
 
 > [!note]
 >
-> Page data have priority over global data. If a page has a variable with the
+> Page data has priority over global data. If a page has a variable with the
 > same name as a global variable, the page variable will be used.
 
 ## Context data
 
-Use the third argument to assign a data value to only a directory. For example:
+Use the third argument to assign a data value to a specific directory. For
+example:
 
 ```js
 // Set the layout value to the directory /pages
@@ -51,7 +52,7 @@ site.data("layout", "pages.vto", "/pages");
 ```
 
 This will assign the data to the `/pages` directory so only the files in this
-directory will access to this value. See
+directory will have access to this value. See
 [shared data](../creating-pages/shared-data.md) for more info.
 
 It's also possible to assign a data value to a specific file:

--- a/docs/configuration/env-variables.md
+++ b/docs/configuration/env-variables.md
@@ -10,8 +10,8 @@ Lume has the following environment variables that you can use with
 <!-- deno-fmt-ignore-start -->
 `LUME_DRAFTS`
 : All pages with the variable `draft: true` are ignored by Lume.
-  With this variable you can configure Lume to export the draft variables too.
-  Useful for development environments.
+  With this variable you can configure Lume to process draft pages too,
+  which is useful for development environments.
 
   ```
   LUME_DRAFTS=true deno task lume
@@ -19,7 +19,7 @@ Lume has the following environment variables that you can use with
 
 `LUME_LOGS`
 : Lume uses the following log levels: `DEBUG`, `INFO`, `WARNING`,
-  `ERROR` and `CRITICAL`. By default is `INFO`, you can change it with this
+  `ERROR` and `CRITICAL`. By default, it is `INFO`, but you can change it with this
   environment variable to have more or less details of the build process. For
   example, to only show critical errors, hiding everything else:
 

--- a/docs/configuration/filters.md
+++ b/docs/configuration/filters.md
@@ -85,8 +85,8 @@ The third argument is an object with different properties:
 - `type`: The type of helper. It can be `tag`, `filter` or any other, depending
   on the template engine.
 - `async`: Set `true` to configure the helper as async.
-- `body`: Set `true` to configure that the helper accept a body (supported only
-  by nunjucks custom tags)
+- `body`: Set `true` to configure the helper to accept a body (only supported by
+  nunjucks custom tags)
 
 Example of custom tag with body:
 
@@ -109,5 +109,5 @@ Hello, {{ user.name }}
 
 > [!note]
 >
-> The method `filter()` is just a shortcut of `helper()` with
-> `{ type: "filter" }`.
+> The `filter()` method is just a shortcut to `helper()` with
+> `{ type: "filter" }` added.

--- a/docs/configuration/ignore-files.md
+++ b/docs/configuration/ignore-files.md
@@ -39,5 +39,5 @@ site.ignore((path) => {
 
 ## Draft files
 
-Pages with the `draft` value as `true` are ignored by Lume unless the
+Pages with the `draft` value set to `true` are ignored by Lume unless the
 environment variable `LUME_DRAFTS` is set to `true`.

--- a/docs/configuration/install-plugins.md
+++ b/docs/configuration/install-plugins.md
@@ -6,8 +6,8 @@ order: 5
 
 Plugins add extra functionality or support for new formats. There are some basic
 plugins installed by default (like support for `markdown`, `yaml` or `json`
-formats), but there are other plugins that you can enable. For example, to add
-the `svgo` plugin (that optimizes SVG files using the SVGO library), you have to
+files), but there are other plugins that you can enable. For example, to add the
+`svgo` plugin (that optimizes SVG files using the SVGO library), you have to
 import the plugin and enable it with `use()` in the config file:
 
 ```js
@@ -23,5 +23,5 @@ export default site;
 
 > [!note]
 >
-> [Go to Plugins](/plugins/) to explore the available plugins and read the
-> specific documentation.
+> [Go to Plugins](/plugins/) to explore the available plugins and read their
+> documentation.

--- a/docs/configuration/using-typescript.md
+++ b/docs/configuration/using-typescript.md
@@ -4,9 +4,9 @@ description: How to use Lume with TypeScript
 order: 6
 ---
 
-Lume is built on top of Deno so it has native support for
+Lume is built on top of Deno, so it has native support for
 [TypeScript](https://www.typescriptlang.org/) and comes with built-in types for
-core features and plugins. It also creates the `deno.json` file importing the
+core features and plugins. It will also create a `deno.json` file importing the
 Lume types using the `compilerOptions.types` array.
 
 ```json
@@ -43,8 +43,8 @@ To create pages and layouts with TSX, you can either use the Lume
 
 ## TypeScript in Templates
 
-`Lume` global namespace has the `Lume.Data` and `Lume.Helpers` interfaces that
-you can use in your pages. For example:
+The `Lume` global namespace has the `Lume.Data` and `Lume.Helpers` interfaces
+that you can use in your pages. For example:
 
 <lume-code>
 
@@ -63,7 +63,7 @@ export default (data: Lume.Data, filters: Lume.Helpers) => {
 
 </lume-code>
 
-Or extend the interface with your own types, for example:
+You can also extend the interface with your own types, for example:
 
 <lume-code>
 

--- a/docs/core/archetypes.md
+++ b/docs/core/archetypes.md
@@ -5,11 +5,11 @@ order: 13
 ---
 
 Archetypes are scripts that create new files in your source directory with some
-preconfigured content. A typical example are the posts of a blog: instead of
-creating a new markdown file from scratch every time you want to create a new
-post, you can create and run an archetype to do this job for you.
+preconfigured content. A typical example are posts on a blog: instead of
+creating a markdown file from scratch every time you want to create a new post,
+you can create and run an archetype to do this job for you.
 
-The archetypes in Lume are JavaScript or TypeScript files, stored in the
+Archetypes in Lume are JavaScript or TypeScript files, stored in the
 `_archetypes` directory that default export a function returning an object with
 the path and the content of the file that is going to be created. For example:
 
@@ -57,8 +57,8 @@ object. If the content is an object, it will be converted to a string depending
 on the extension of the path:
 
 - If the `path` has the `yml` or `yaml` extension, the object will be
-  stringified to YAML.
-- If the `path` has the `json` extension, the object will be stringified to
+  stringified as YAML.
+- If the `path` has the `json` extension, the object will be stringified as
   JSON.
 - For other extensions, the object will be converted to frontmatter + text.
 
@@ -85,7 +85,7 @@ content: Page content
 
 </lume-code>
 
-Same example but for JSON conversion:
+Same example, but for JSON conversion:
 
 <lume-code>
 
@@ -110,7 +110,7 @@ export default function () {
 
 </lume-code>
 
-Same example but for any other extension (for example, `md`):
+Same example, but for any other extension (for example, `md`):
 
 <lume-code>
 
@@ -138,8 +138,8 @@ Page content
 
 ## Passing arguments
 
-Arguments allow to pass variables to the archetype to configure how the new
-content is created. For example, we want to create new pages based on the
+Arguments allow passing variables to the archetype to configure how the new
+content is created. For example, if we want to create new pages based on the
 provided title:
 
 ```ts
@@ -161,8 +161,8 @@ export default function (title: string) {
 This function uses the `title` argument to generate the final path and the
 content. Now you can run `deno task lume new page "My first page"` (or
 `lume new page "My first page"` if you're using the Lume CLI), and the new
-`/pages/my-first-page.md` file will be created. Any extra argument passed to the
-CLI command will be passed to the archetype's function.
+`/pages/my-first-page.md` file will be created. Any extra arguments passed to
+the CLI command will be passed to the archetype's function.
 
 ## Multiple files
 

--- a/docs/core/basename-parsers.md
+++ b/docs/core/basename-parsers.md
@@ -1,15 +1,15 @@
 ---
 title: Basename parsers
-description: Parse the file's basename to extract extra data
+description: Parse file basenames to extract extra data
 order: 10
 ---
 
-When Lume is scanning the source folder, it can extract automaticaly some info
+When Lume is scanning the source folder, it can automatically extract some info
 from the basename of files (the filename after removing the extension) and
 folders.
 
-For example, let's say you want to create the variable `order` to sort the pages
-in a menu. A way to make this variable explicit is to save your pages with the
+For example, let's say you want to create the variable `order` to sort pages in
+a menu. A way to make this variable explicit is to save your pages with the
 `[order].` prefix:
 
 ```txt
@@ -21,8 +21,8 @@ in a menu. A way to make this variable explicit is to save your pages with the
 ```
 
 One of the advantages of making this variable explicit in the filesystem is that
-you can see in your text editor the source files sorted in the same way as they
-will be in the site.
+you can see the source files sorted the same way in your editor as well as on
+the final site.
 
 In Lume, the filename is used by default to generate the final URLs
 ([more info](../creating-pages/page-files.md)), so the page files above
@@ -35,7 +35,7 @@ generates the following URLs:
 /4.advanced/
 ```
 
-That could work but what we really want is to remove the order prefix and store
+That could work, but what we really want is to remove the order prefix and store
 it in the page data. To do that, we can register a basename parser using the
 function `site.parseBasename` in our _config.ts file:
 
@@ -75,13 +75,13 @@ anything, so nothing will be changed.
 > data (a.k.a. the front matter). **The front matter can override a variable
 > defined in the basename parser.**
 
-The `parseBasename` function is used not only for files but also folders. This
-allows to extract values from a folder name and store them as
+The `parseBasename` function is used for both files and folders. This allows
+extracting values from a folder name and storing them as
 [shared data](../creating-pages/shared-data.md), so they are available to all
 pages inside.
 
 ## Extract dates
 
-Lume is configured by default with a basename parser to extract dates from the
+Lume, by default, is configured with a basename parser to extract dates from
 filenames. See [page dates](../creating-pages/page-files.md#page-date) for more
 info.

--- a/docs/core/components.md
+++ b/docs/core/components.md
@@ -5,13 +5,14 @@ order: 8
 ---
 
 Components are template pieces that you can use in other templates. Some
-template engines like Vento, Nunjucks, Pug or Liquid have ways to reuse codes
-(like includes, macros, etc). The Lume components have the following advantages:
+template engines like Vento, Nunjucks, Pug or Liquid already have ways to reuse
+code (like includes, macros, etc). Lume components have the following
+advantages:
 
 - They are template engine agnostic. For example, you can create your components
   in JSX or JavaScript and use them in Nunjucks.
-- They can generate not only the HTML code but also the CSS and JavaScript code
-  needed on the client side.
+- They don't just generate HTML, but also the CSS and JavaScript needed for them
+  on the client side.
 - They are automatically available everywhere; no need to import them manually.
 - For ESM module-based components (like JavaScript, TypeScript, JSX or TSX) it's
   the only way to hot-reload components without stopping and restarting the
@@ -20,12 +21,12 @@ template engines like Vento, Nunjucks, Pug or Liquid have ways to reuse codes
 > [!important]
 >
 > **Lume components don't run in the browser**. They are intended to generate
-> static HTML code on building time.
+> static HTML code at build time.
 >
 > For interactive client-side components (with `onclick` callbacks and similar
 > stuff) you may want to use the [esbuild plugin](../../plugins/esbuild.md) to
-> compile your JavaScript code. But the code architecture is up to you (**Lume
-> is not a frontend framework**).
+> compile your JavaScript code, but the architecture is up to you. **Lume is not
+> a frontend framework**.
 
 ## Create your own components
 
@@ -41,7 +42,7 @@ a button could be stored in `_components/button.vto`:
 ```
 
 This component is available in your layouts under the `comp` variable (you can
-configure a different variable name in `_config.ts`). It's a global variable
+configure a different variable name in `_config.ts`). This is a global variable
 that contains all components. In our example, we can render the button component
 with the `comp.button()` function:
 
@@ -117,7 +118,7 @@ export default function ({ comp }) {
 
 ### Nested components
 
-In Vento you can nest components in this way:
+In Vento you can nest components like this:
 
 ```vento
 {{ comp Container }}
@@ -152,11 +153,11 @@ The content of the components are passed through the `content` variable:
 
 ## Component assets
 
-Components can export CSS and JS code. To do that, the component needs to export
+Components can export CSS and JS code. To do this, the component needs to export
 `css` or `js` variables.
 
 In our example, we may want to apply some styles to the button. In a Nunjucks
-template, the way to export data is using a front matter:
+template, the way to export data is using front matter:
 
 ```vento
 ---
@@ -171,9 +172,9 @@ css: |
 
 This CSS code will be exported in your `dest` folder in the `/components.css`
 file together with the CSS code of other used components. Note that if the
-component is not used, the CSS code won't be exported. This is an interesting
-feature that allows having a library of many components and only exporting the
-CSS and JS code that you only need.
+component is not used, the CSS code won't be exported. This is a useful feature
+that allows having a library of many components and only exporting the CSS and
+JS code that you only need.
 
 ## Organize your components
 
@@ -234,7 +235,7 @@ site.component("ui", {
 });
 ```
 
-Now, you can use the component as always:
+Now, you can use the component like before:
 
 ```vento
 {{ comp.ui.button({ text: "Login" }) }}

--- a/docs/core/concepts.md
+++ b/docs/core/concepts.md
@@ -4,8 +4,8 @@ description: About different types of files, plugins and extensions.
 order: 1
 ---
 
-The way Lume works is simple: it reads files in your `src` directory,
-processes the content, and saves the final files into the `dest` folder.
+The way Lume works is simple: it reads files in your `src` directory, processes
+the content, and saves the final files into the `dest` folder.
 
 There are different types of files:
 
@@ -27,9 +27,9 @@ example:
 6. Save the output file as `/my-page/index.html`.
 
 By default, Lume interprets the following formats as regular page files, so they
-are loaded, processed and exported to the `dest` folder: `.md`, `.markdown`, `.vto`,
-`.page.json`, `.page.js`, `.page.ts` and `.yaml`. Use `site.loadPages()` to add
-additional extensions:
+are loaded, processed and exported to the `dest` folder: `.md`, `.markdown`,
+`.vto`, `.page.json`, `.page.js`, `.page.ts` and `.yaml`. Use `site.loadPages()`
+to add additional extensions:
 
 ```ts
 // To load pages with the extension .foo
@@ -40,14 +40,14 @@ site.loadPages([".foo"]);
 > [!note]
 >
 > If you're using any plugin to provide support for a new template engine, like
-> [pug](../../plugins/pug.md) or [eta](../../plugins/eta.md), then you don't need to
-> run `site.loadPages()` because the plugin does it for you.
+> [pug](../../plugins/pug.md) or [eta](../../plugins/eta.md), then you don't
+> need to run `site.loadPages()` because the plugin will do it for you.
 
 ### Asset pages
 
-These are pages intended to output assets, like `.css` files, `.js` or images. They
-are very similar to regular pages but with a couple of differences. Let's take
-`my-styles.css` as an example:
+These are pages intended to output assets, like `.css` files, `.js` or images.
+They are very similar to regular pages but with a couple of differences. Let's
+take `my-styles.css` as an example:
 
 1. Load the content of the file.
 2. Run preprocessors
@@ -75,15 +75,15 @@ site.loadAssets([".webp"], binaryLoader);
 >
 > If you're using any plugin to process assets, like
 > [postcss](../../plugins/postcss.md), [esbuild](../../plugins/esbuild.md) or
-> [svgo](../../plugins/svgo.md), then you don't need to run `site.loadAssets()` because
-> the plugin does it for you.
+> [svgo](../../plugins/svgo.md), then you don't need to run `site.loadAssets()`
+> because the plugin will do it for you.
 
 ## Data files
 
-Data files are files saved as `_data.*` or in `_data/` directories and
-contain data shared with the page files. The following files are interpreted as
-data files: `_data.yaml`, `_data.ts`, `_data.js`, `_data.json`. If you want to
-load additional data formats, use `site.loadData()` function:
+Data files are files saved as `_data.*` or in `_data/` directories and contain
+data shared with the page files. The following files are interpreted as data
+files: `_data.yaml`, `_data.ts`, `_data.js`, `_data.json`. If you want to load
+additional data formats, use `site.loadData()` function:
 
 ```ts
 // Load .toml files
@@ -93,8 +93,8 @@ site.loadData([".toml"], tomlLoader);
 ## Static files
 
 These are files that are exported to the `dest` folder but don't need to be
-processed, so Lume doesn't load the content, but only copies them. They are copied
-as-is using the `site.copy()` function.
+processed, so Lume doesn't load the content, but only copies them. They are
+copied as-is using the `site.copy()` function.
 [See more about copy](../configuration/copy-static-files.md).
 
 ```ts
@@ -107,17 +107,17 @@ site.copy([".pdf"]);
 
 ## Includes
 
-These are files loaded by pages, for example, the layouts or templates. By
-default, they are placed in the `_includes` folder, but you can configure it in
-the [config file](../configuration/config-file.md#includes).
+These are files loaded by pages, such as layouts or templates. By default, they
+are placed in the `_includes` folder, but you can configure it in the
+[config file](../configuration/config-file.md#includes).
 
 ## Components
 
-By default, these are saved in the `_components` folder and store reusable pieces of
-code that you can use in your templates.
+By default, these are saved in the `_components` folder and store reusable
+pieces of code that you can use in your templates.
 
 ## Plugins
 
 Everything in Lume is a plugin. Even the support of core formats like `.md`,
-`.yaml`, `.json` etc is provided by some
-[plugins that **enabled by default**](../../../plugins/index.yml?status=enabled)
+`.yaml`, `.json` etc is provided by
+[plugins that are **enabled by default**](../../../plugins/index.yml?status=enabled)

--- a/docs/core/events.md
+++ b/docs/core/events.md
@@ -1,12 +1,12 @@
 ---
 title: Events
-description: A list of all the events which Lume will dispatch in the lifecycle
+description: A list of all events which Lume will dispatch in its lifecycle
 order: 10
 ---
 
-Lume has an events system to run some code at certain times during the compiling
-process. You can configure those events in the `_config.js` file with the
-function `addEventListener`.
+Lume has an events system to run code at certain times during the compilation
+process. You can configure those events in your configuration file with the
+`addEventListener` function.
 
 ## beforeBuild
 
@@ -31,7 +31,7 @@ site.addEventListener("beforeBuild", () => {
 ## afterBuild
 
 This event is triggered after building the site. Note that if you are watching
-the files with `lume --serve`, this is **only executed once** after the initial
+the files with `lume --serve`, this is **only executed once**, after the initial
 build. Use **afterUpdate** for subsequent changes.
 
 ```js
@@ -44,7 +44,7 @@ site.addEventListener("afterBuild", (event) => {
 
 ## beforeUpdate
 
-This event is triggered every time a change is detected on building the site
+This event is triggered every time a change is detected when building the site
 with `lume --serve`.
 
 ```js
@@ -64,8 +64,7 @@ site.addEventListener("beforeUpdate", () => {
 
 ## afterUpdate
 
-This event is triggered after re-building the site after detecting changes with
-`lume --serve`.
+This event is triggered after re-building the site with `lume --serve`.
 
 ```js
 site.addEventListener("afterUpdate", (event) => {
@@ -79,11 +78,11 @@ site.addEventListener("afterUpdate", (event) => {
 ## afterLoad
 
 Event triggered after all files in the source folder are loaded (but not
-processed). It allows to do low-level operations like renaming files, etc.
+processed). It lets you do low-level operations like renaming files.
 
 ## beforeRender
 
-This event is triggered just after all pages are loaded but before they are
+This event is triggered after all pages are loaded, but before they are
 rendered.
 
 ```js
@@ -95,7 +94,7 @@ site.addEventListener("beforeRender", (event) => {
 
 ## afterRender
 
-This event is triggered just after all pages are rendered but before they are
+This event is triggered after all pages are rendered, but before they are
 processed.
 
 ```js
@@ -106,7 +105,7 @@ site.addEventListener("afterRender", () => {
 
 ## beforeSave
 
-This event is triggered just before saving the generated pages.
+This event is triggered before saving the generated pages.
 
 ```js
 site.addEventListener("beforeSave", () => {
@@ -152,7 +151,7 @@ site.addEventListener("afterBuild", "gzip -r _site site.gz").
 ## Events options
 
 Similar to
-[web APIs](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)
+[web APIs](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener),
 the third argument of `addEventListener` allows customizing the event listener.
 The available options are:
 
@@ -169,7 +168,7 @@ site.addEventListener("afterUpdate", () => {
 });
 ```
 
-Example of signal usage:
+Example using signals:
 
 ```js
 const controller = new AbortController();

--- a/docs/core/loaders.md
+++ b/docs/core/loaders.md
@@ -10,8 +10,8 @@ or plain text.
 
 ## Creating a loader
 
-Creating a custom loader is really easy: you only have to create a function that
-reads the content of a file and returns
+Creating a custom loader is really easy: you just have to create a function that
+reads the content of a file and then returns
 [a data object](../advanced/the-data-model.md).
 
 Let's say you want to add support for the `toml` format, using the
@@ -63,10 +63,10 @@ You may want to load TOML files, process them and export as `.toml` files, not
 site.loadAssets([".toml"], tomlLoader);
 ```
 
-Now, the `*.toml` files are loaded and saved as `toml`. The function
-`loadAssets` is useful to load assets files, like `css`, `js`, `svg`, that you
-want to transform (bundle, minify...) and save them while keeping the same
-extension, instead of renaming them to `html`.
+Now, any `*.toml` files are loaded and saved as `toml`. The function
+`loadAssets` is useful for loading static assets like `css`, `js`, and `svg`
+files that you want to transform (bundle, minify...) and save them while keeping
+the same extension, instead of renaming them to `html`.
 
 **Note:** you can't use the same extension to generate pages and assets, so a
 way to have support for both is adding a sub-extension (like `.page`) for pages.
@@ -93,7 +93,7 @@ for pages and `*.js` for JavaScript assets).
 
 ## Template engines
 
-Lume supports several template engines to render your pages, like Vento,
+Lume supports several template engines to render your pages, such as Vento,
 Nunjucks, Pug or Eta. It's easy to extend this support for more template
 engines: you only need to create a class implementing the `Lume.Engine`
 interface. Let's see an example using
@@ -126,7 +126,7 @@ export default class HandlebarsEngine implements Lume.Engine {
 }
 ```
 
-To use this template engine, pass it to the options argument of the `loadPages`
+To use this template engine, pass it in the options argument of the `loadPages`
 function:
 
 ```ts
@@ -139,8 +139,8 @@ site.loadPages([".hbs"], {
 });
 ```
 
-Now, all files with the `.hbs` extension will be loaded using the `textLoader`
-and rendered using the Handlebars engine.
+Now, all files with the `.hbs` extension will be loaded with the `textLoader`
+loader and rendered using the Handlebars engine.
 
 > [!note]
 >

--- a/docs/core/merged-keys.md
+++ b/docs/core/merged-keys.md
@@ -1,6 +1,6 @@
 ---
 title: Merged keys
-description: Configure how the data is merged
+description: Configure how data is merged
 order: 12
 ---
 
@@ -27,8 +27,8 @@ files, **in this order of priority**.
 
 ## Object mode merging
 
-On merging variables, **the complete value is overridden**. But you may want to
-merge some values in a different way. For example, let's say we have the
+When merging variables, **the complete value is overridden**. However, you may
+want to merge some values differently. For example, let's say we have the
 following two data files, one in the root and the other in a subfolder. Both
 files have a `site` variable with different values:
 
@@ -50,7 +50,7 @@ site:
 All pages in the subfolder (and sub-subfolders) will have the latest version of
 the variable that has the `author` subkey but missing the `title` value, because
 the whole variable is overridden. You can change this behaviour using the
-special value `mergedKeys`. This value indicates to Lume how to merge some keys:
+special value `mergedKeys`. This value indicates how to merge specific keys:
 
 <lume-code>
 
@@ -70,10 +70,10 @@ site:
 
 </lume-code>
 
-In this example, we are indicating to Lume that the variable `site` must be
-merged using the `object` mode. Now, the result of the variable `site` is an
-object including the properties of the parent variable and only overrides the
-properties with the same name. So the result will be something like this:
+In this example, we are indicating that the variable `site` must be merged using
+the `object` mode. Now, the result of the variable `site` is an object including
+the properties of the parent variable and only overrides the properties with the
+same name. So the result will be something like this:
 
 ```yml
 site:
@@ -87,14 +87,14 @@ properties. A recursive option may be added in the future.
 > [!note]
 >
 > The `mergedKeys` variable is also merged with other `mergedKeys` variables in
-> subfolders and pages and using always the `object` mode. This means that you
-> can define this variable in the root `_data` file of the site and override it
-> in specific subfolders.
+> subfolders and pages using the `object` mode. This means that you can define
+> this variable in the root `_data` file of the site and override it in specific
+> subfolders.
 
 ## array mode
 
 There's another merge mode for arrays. In this mode, the merge result is an
-array with all values found in all `_data` levels. For example:
+array with all values found at all `_data` levels. For example:
 
 <lume-code>
 
@@ -126,12 +126,12 @@ category:
 
 It's an array with all values present in all parent `_data` contexts. The result
 includes only unique values: if the same value is repeated in different `_data`
-contexts, it's included only once in the result.
+contexts, it's only included once in the result.
 
 ## stringArray mode
 
-There's a special case in which you want to make sure that all values of the
-array are strings. Let's see the following example:
+There's a special case where you want to make sure that all values of the array
+are strings. Look at the following example:
 
 <lume-code>
 

--- a/docs/core/multiple-pages.md
+++ b/docs/core/multiple-pages.md
@@ -1,14 +1,14 @@
 ---
 title: Create multiple pages
-description: Generators allows to create multiple pages from an unique source file
+description: Generators allow creating multiple pages from one unique source file
 order: 8
 related:
   - /docs/core/searching/
   - /docs/core/render-order/
 ---
 
-It's possible with Lume to generate more than one page from the same source
-file. This is useful to generate pages programmatically using an external source
+It's possible to generate more than one page from the same source file with
+Lume. This is useful to generate pages programmatically using an external source
 like a database or an API.
 
 ## Basic example
@@ -41,7 +41,7 @@ URLs of the pages be unique.
 ## Multiple pages with layouts
 
 Every page is an object with the page data. In the previous example, every page
-has the `url` and `content` properties,to define the content and URL of every
+has the `url` and `content` properties, to define the content and URL of every
 page. If you want to use a layout to generate the page content, you have to
 export the `layout` keyword with the layout name and the data that will be used
 in the layouts:
@@ -156,5 +156,5 @@ generate a new page per article. Each yielded article contains the URL and other
 properties you like (title, category, tag, body, etc.). We are exporting the
 `layout` value so all pages will use the same layout to render.
 
-Another common use case is for pagination. Go to
+Another common use case is pagination. Go to
 [Search and paginate](./searching.md) for more info.

--- a/docs/core/multiple-template-engines.md
+++ b/docs/core/multiple-template-engines.md
@@ -4,15 +4,15 @@ description: Overriding the behavior of a template engine
 order: 13
 ---
 
-By default, the template engine used to render a file is decided according to
-the file extension. For example, an `.md` file uses Markdown, `.vto` file uses
-Vento and so on.
+By default, the template engine used to render a file is chosen based on its
+file extension. For example, `.md` files use Markdown, `.vto` files use Vento,
+and so on.
 
 You can override this default behaviour with the `templateEngine` option. Any
-page having this variable will use it to decide the template engine instead of
-the extension.
+page with this variable will use it to choose the template engine instead of the
+extension.
 
-The following example is an `.md` file but it is configured to use Vento to
+The following example is an `.md` file, but it is configured to use Vento to
 render (instead of Markdown).
 
 ```yml

--- a/docs/core/processors.md
+++ b/docs/core/processors.md
@@ -4,8 +4,8 @@ description: A guide on extending Lume with custom processors
 order: 15
 ---
 
-A processor is a function to transform the content of pages just **after the
-page is rendered**. Let's see an example of a processor to minify HTML pages:
+A processor is a function to transform the content of pages **after the page is
+rendered**. Let's see an example of a processor to minify HTML pages:
 
 ```js
 function minifyHTML(pages) {
@@ -22,13 +22,13 @@ If you want to use this processor to build your site, you can register it in the
 site.process([".html"], minifyHTML);
 ```
 
-Now, all HTML pages are minified.
+Now, all HTML pages will be minified.
 
 ## The page object
 
 As you can see in the previous example, the function receives an array of
-objects with the pages. The page object has not only the page content but much
-more data:
+objects, where each object contains a page. Each page object has the page
+content, as well as much more data:
 
 ```js
 function process(pages) {
@@ -41,8 +41,8 @@ function process(pages) {
 }
 ```
 
-For example, let's say you only want to minify the pages with the value `minify`
-is `true`:
+For example, let's say you only want to minify the pages where the value
+`minify` is set to `true`:
 
 ```js
 site.process([".html"], (pages) => {
@@ -75,7 +75,7 @@ site.process([".html"], (pages) => {
 
 ## Process assets
 
-For non-HTML pages (like CSS or JavaScript files), you can use the processors to
+For non-HTML pages (like CSS or JavaScript files), you can use processors to
 compile CSS, minify JavaScript code or minify images.
 
 ```js
@@ -100,8 +100,8 @@ site.process([".js"], function (pages) {
 
 If you need to execute a function **before rendering** (for example, to
 configure a custom template engine or add extra data to some pages), you can use
-a **preprocessor**. Preprocessors work like processors, but with they are
-executed before rendering.
+a **preprocessor**. Preprocessors work like processors, but they are executed
+before rendering.
 
 Let's create a preprocessor to include a variable with the source filename:
 
@@ -116,8 +116,8 @@ site.preprocess([".html"], (pages) => {
 ## Create pages dynamically
 
 Processors can generate additional pages (or remove them). The second argument
-of the (pre)processors contains an array with all pages of the site. You can
-modify this array to add or remove pages dynamically. For example:
+to (pre)processors contains an array with all pages of the site. You can modify
+this array to add or remove pages dynamically. For example:
 
 ```js
 import { Page } from "lume/core/file.ts";
@@ -144,7 +144,7 @@ site.process([".css"], (filteredPages, allPages) => {
 
 ## Remove pages dynamically
 
-To remove a page dynamically you have to remove it from the array of pages in
+To remove a page dynamically, you have to remove it from the array of pages in
 the second argument:
 
 ```ts
@@ -166,10 +166,10 @@ etc). To decide if a page must use a registered processor or preprocessor, Lume
 searches the extension of the input file (like `.md` or `.vto`) or the output
 file (like `.html` or `.css`).
 
-Another interesting thing is they are executed in the same order as they are
-defined. This allows chaining different processors to the same file extension.
-For example: two processors for the `.css` extension, one to compile the code
-and another to minify.
+Another interesting thing is that they are executed in the same order as they
+are defined. This allows chaining different processors to the same file
+extension. For example: two processors for the `.css` extension, one to compile
+the code and another to minify.
 
 ## Global (pre)processors
 

--- a/docs/core/remote-files.md
+++ b/docs/core/remote-files.md
@@ -1,10 +1,10 @@
 ---
 title: Remote files
-description: Load remote files as fallback of missing local files
+description: Load remote files as a fallback of missing local files
 order: 16
 ---
 
-In Lume it's possible to use remote files as if they were local files. To
+In Lume, it's possible to use remote files as if they were local files. To
 configure a remote file, you must set a local name and a remote URL in your
 `_config.ts` file using the `remoteFile()` function. For example:
 
@@ -18,8 +18,8 @@ site.remoteFile("styles.css", "https://example.com/theme/styles.css");
 export default site;
 ```
 
-This indicates to Lume that if the file `styles.css` **doesn't exist locally**
-the remote URL must be used. Note that the file **won't be saved in the project
+This indicates that if the file `styles.css` **doesn't exist locally**, the
+remote URL must be used. Note that the file **won't be saved in the project
 folder**, but it's in memory.
 
 If you want to copy this file statically:
@@ -64,14 +64,14 @@ Page content
 
 ## Override remote files
 
-If a remote file exists locally (in the previous examples: `styles.css` and
-`_includes/layouts/main.vto`) the local file will be used instead of the remote
+If a remote file exists locally(in the previous examples: `styles.css` and
+`_includes/layouts/main.vto`), the local file will be used instead of the remote
 one. This is useful for creating themes with all templates and assets loaded
 remotely but allowing overriding some files locally in order to customize the
 theme. As an example, see the
 [Simple blog theme](https://github.com/lumeland/theme-simple-blog).
 
-## Limits of the remote files
+## Limits of remote files
 
 Remote files work in most cases, because they are integrated natively in Lume's
 file system
@@ -81,11 +81,10 @@ uses `extends "filename"`, Vento uses `{{ include "filename" }}`, Liquid and
 Nunjucks use `{% include "filename" %}`, etc.
 
 The template engines [Eta](../../plugins/eta.md),
-[Liquid](../../plugins/liquid.md) and [Pug](../../plugins/pug.md) don't allow to
-customize the way to load the files, and cannot use Lume file system, hence they
-cannot include remote files. If you want to use remote templates,
-[Vento](../../plugins/vento.md) or [Nunjucks](../../plugins/nunjucks.md) are
-good options.
+[Liquid](../../plugins/liquid.md) and [Pug](../../plugins/pug.md) don't allow
+customizing how they load files, hence they cannot include remote files. If you
+want to use remote templates, [Vento](../../plugins/vento.md) or
+[Nunjucks](../../plugins/nunjucks.md) are good options.
 
 ### Cache files
 
@@ -113,5 +112,5 @@ LUME_NOCACHE=true deno task serve
 ### Import modules
 
 JavaScript/TypeScript modules imported as `import foo from "./filename.ts"` are
-not managed by Lume file system, but you can use import maps for a similar
+not managed by Lume's file system, but you can use import maps for a similar
 behavior.

--- a/docs/core/render-order.md
+++ b/docs/core/render-order.md
@@ -1,13 +1,13 @@
 ---
 title: Render order
-description: Configure the rendering order of the pages
+description: Configure the rendering order of pages
 order: 9
 related:
   - /docs/core/multiple-pages/
   - /docs/core/searching/
 ---
 
-In Lume all pages are rendered at the same time. This works well in most cases,
+In Lume, all pages are rendered at the same time. This works well in most cases,
 but sometimes you want to make sure a page is rendered before or after others.
 The most typical example is with auto-generated pages. Let's say you have a page
 that generates multiple pages dynamically using data from an external API:

--- a/docs/core/scoped-updates.md
+++ b/docs/core/scoped-updates.md
@@ -1,12 +1,12 @@
 ---
 title: Scoped updates
-description: How to optimize the update process in the watch mode.
+description: How to optimize the update process in watch mode.
 order: 11
 ---
 
 In Lume, any change in the watch mode (with `lume --serve` or `lume --watch`),
-**rebuilds the entire site again**. This happens because it's almost impossible
-to know in advance which pages will be affected by a change in any file. For
+**rebuilds the entire site**. This happens because it's almost impossible to
+know in advance which pages will be affected by a change in any file. For
 example:
 
 - A change in a CSS file can affect other CSS files that `@import` it (if you
@@ -18,8 +18,8 @@ Lume is conservative about the updating process to make sure that any change in
 any file will be correctly applied to all pages. This is why the entire site is
 rebuilt after any change.
 
-In large sites or sites with expensive processors (like bundlers) this can
-increase the duration of the update process. There's a way to customize this
+In large sites or sites with expensive processors like bundlers, this can
+increase the duration of the update process. Lume offers a way to customize this
 behavior using **Scoped Updates**. It's a way to define different "scopes"
 (collections of independent files whose changes won't affect other pages).
 

--- a/docs/core/scripts.md
+++ b/docs/core/scripts.md
@@ -1,6 +1,6 @@
 ---
 title: Scripts
-description: A guide to use Lume as a script runner
+description: Using Lume as a script runner
 order: 11
 ---
 
@@ -17,8 +17,8 @@ Now, you can run this script from the CLI with `lume run deploy`.
 ## Running multiple commands
 
 You can create a script to execute multiple commands, **one after another.**
-There are two ways to do that: by adding more arguments or joining the different
-commands with `&&`. For example:
+There are two ways to do that: either adding more arguments or joining the
+different commands with `&&`. For example:
 
 ```js
 site.script(
@@ -34,7 +34,7 @@ site.script(
 );
 ```
 
-Now, by running `lume run save-site`, these two commands will be executed.
+Now, when you run `lume run save-site`, these two commands will be executed.
 
 If you don't need to execute the commands in series but in **parallel**, use an
 array of commands or the character `&`:
@@ -71,8 +71,7 @@ site.script("compress-and-upload", "compress", "upload");
 
 ## Custom functions
 
-Scripts not only can execute CLI commands but also JavaScript functions. For
-example:
+Scripts can execute both CLI commands and JavaScript functions. For example:
 
 ```js
 site.script("add-date-published", () => {

--- a/docs/core/searching.md
+++ b/docs/core/searching.md
@@ -1,6 +1,6 @@
 ---
 title: Search and paginate
-description: Using the search and paginate helper to create dynamic pages.
+description: Using the search and paginate helpers to create dynamic pages.
 order: 8
 related:
   - /docs/core/multiple-pages/
@@ -36,8 +36,8 @@ The `search` helper is very powerful and has more interesting features.
 ## Pagination
 
 In Lume [you can create multiple pages using a generator](./multiple-pages.md).
-Pagination is basically the same thing: the creation of multiple pages using the
-result of a search.
+Pagination is basically the same thing: creating multiple pages using the result
+of a search.
 
 Let's say we want to paginate some pages in groups of 10 elements. We could do
 it manually with a generator:

--- a/docs/core/server.md
+++ b/docs/core/server.md
@@ -21,8 +21,8 @@ server.start();
 console.log("Listening on http://localhost:8000");
 ```
 
-This code starts a local server on the port `8000` and serves the static files
-in the `_site` folder.
+This code starts a local server on port `8000` and serves static files from the
+`_site` folder.
 
 ## Events
 
@@ -34,9 +34,9 @@ server.addEventListener("start", () => {
 });
 ```
 
-## Middlewares
+## Middleware
 
-To customize how the server handles the requests and responses, there's a simple
+To customize how the server handles requests and responses, there's a simple
 middleware system with the following signature:
 
 ```js
@@ -54,7 +54,7 @@ The request and response objects are standard
 [`Response`](https://developer.mozilla.org/docs/Web/API/Response) classes, no
 magic here.
 
-Lume provides some middlewares for common use cases:
+Lume provides some middleware for common use cases:
 
 ```ts
 import Server from "lume/core/server.ts";
@@ -68,4 +68,4 @@ server.start();
 ```
 
 Go to [Plugins/middleware](/plugins/?status=all&middleware=on) for a list of all
-middlewares provided by Lume.
+middleware plugins provided by Lume.

--- a/docs/creating-pages/layouts.md
+++ b/docs/creating-pages/layouts.md
@@ -55,9 +55,9 @@ the title, and `content` with the rendered Markdown content of the page.
 ## Layout data
 
 Layouts can have additional data that will be merged with the data from the
-page. Note that variables defined in the pages have precedence over the
-variables in the layouts. This means that you can set default values in the
-layouts and override them within the pages.
+page. Note that variables defined in pages have precedence over the variables in
+the layouts. This means that you can set default values in the layouts and
+override them within the pages.
 
 A layout can be wrapped around another layout. Just set a `layout` variable in
 the front matter. In the following examples, the layout uses the

--- a/docs/creating-pages/page-data.md
+++ b/docs/creating-pages/page-data.md
@@ -55,10 +55,10 @@ export default () => "<p>This is the page content</p>";
 
 In the examples above, all pages contain two variables: `title` and `url`.
 
-In the formats with front matter (like Markdown, Vento and Nunjucks), the
-content is defined below the front matter. Formats that don't use front matter
-export the content as the `content` variable or, optionally, as a default export
-(like in `page.page.js`).
+In formats with front matter (like Markdown, Vento and Nunjucks), the content is
+defined below the front matter. Formats that don't use front matter export the
+content as the `content` variable or, optionally, as a default export (like in
+`page.page.js`).
 
 ## Standard variables
 
@@ -86,12 +86,12 @@ values are:
 
 ### draft
 
-The draft variable mark this page as draft, which means it will ignored unless
-the environment variable `LUME_DRAFTS` is defined as `"true"`.
+The draft variable marks this page as a draft, which means it will be ignored
+unless the environment variable `LUME_DRAFTS` is set to `"true"`.
 
 ### layout
 
-To define the layout that is used to render the page. See [Layouts](layouts.md)
+Defines the layout that is used to render the page. See [Layouts](layouts.md)
 for more info.
 
 ### tags

--- a/docs/creating-pages/page-files.md
+++ b/docs/creating-pages/page-files.md
@@ -1,6 +1,6 @@
 ---
 title: Page files
-description: How Lume generate your site based on the source file structure
+description: How Lume generates your site based on the source file structure
 order: 1
 ---
 
@@ -58,9 +58,9 @@ and others are configured by default to serve the `/404.html` page if the
 requested file doesn't exist. It's almost a standard when serving static sites.
 
 Pretty URLs option would convert the 404 page to `/404/index.html`, and this
-conflicts which conflicts with this standard way to serve 404 pages, so this is
-why it's disabled. Note that you can change this behavior by explicitly setting
-the `url` variable in the front matter of the page.
+conflicts with this standard way to serve 404 pages, so this is why it's
+disabled. Note that you can change this behavior by explicitly setting the `url`
+variable in the front matter of the page.
 
 ## Page date
 
@@ -68,7 +68,8 @@ All pages have a `date` variable with the file creation date. This value can be
 used to order the pages (in a blog, for example). If you want to define a
 different date, you can prepend it to the filename using the `yyyy-mm-dd` syntax
 followed by a hyphen `-` or an underscore `_` (or `yyyy-mm-dd-hh-ii-ss` if you
-also need the time). Note that this part is removed in generating the final url:
+also need the time). Note that this part is removed when generating the final
+url:
 
 ```txt
 .

--- a/docs/creating-pages/shared-data.md
+++ b/docs/creating-pages/shared-data.md
@@ -1,6 +1,6 @@
 ---
 title: Shared data
-description: Add custom data that can be shared by all pages in a directory
+description: Add custom data shared by all pages in a directory
 order: 5
 ---
 
@@ -9,8 +9,8 @@ data accessible by some or all pages. Shared data must be saved in the `_data`
 directory or `_data.*` files with extensions like `.json`, `.yaml`, `.js` or
 `.ts`.
 
-The formats `.json` and `.yaml` are useful for static data. `.js` and `.ts` fit
-better for dynamic data (for example, data fetched from an API or a database):
+`.json` and `.yaml` files are useful for static data, while `.js` and `.ts` fit
+better for dynamic data (such as data fetched from an API or a database):
 
 <lume-code>
 
@@ -48,10 +48,10 @@ export { people };
 
 </lume-code>
 
-## The `_data.*` files
+## `_data.*` files
 
-Any file named as `_data.*` is loaded and its content is accessible by all pages
-in the same directory or subdirectory.
+Any file named `_data.*` is loaded and its content is accessible by all pages in
+the same directory or subdirectory.
 
 ```sh
 ├── _data.yaml      # Data shared with all pages
@@ -66,10 +66,9 @@ in the same directory or subdirectory.
         └── example2.md
 ```
 
-As you can see, the shared data is propagated in a cascade following the
-directory structure. A typical use case is to store those variables that are
-common to all pages in the same directory so you don't have to repeat it for
-every page.
+As you can see, the shared data is propagated through the directory structure. A
+typical use case is to store variables that are common to all pages in the same
+directory, so you don't have to include it on every page.
 
 ## The `_data` directories
 
@@ -122,4 +121,4 @@ export default function ({ documents }) {
 </lume-code>
 
 Like `_data.*` files, you can have `_data` directories in different locations so
-they are shared only with all pages in the same directory or subdirectories.
+they are shared only with pages in the same directory or subdirectories.

--- a/docs/creating-pages/tags.md
+++ b/docs/creating-pages/tags.md
@@ -7,12 +7,12 @@ order: 7
 You can assign one or multiple tags to pages using the `tags` variable. Tags
 allows you to group content in interesting ways.
 
-For example, in a blog site, you may want to group posts of different
+For example, in a blog site, you may want to group posts from different
 categories:
 
 ```yaml
 ---
-title: The history of the static site generators
+title: The history of static site generators
 tags:
   - post
   - ssg
@@ -21,7 +21,7 @@ tags:
 
 This post has two tags, one used to identify the type of page (post) and another
 with the topic (ssg). To collect all pages tagged as `post` in the layouts, use
-the `search` object:
+the `search` function:
 
 ```vento
 <ul>
@@ -31,7 +31,7 @@ the `search` object:
 </ul>
 ```
 
-And to get all pages tagged as `post` and `ssg` add the two tags names separated
+And to get all pages tagged as `post` and `ssg`, add the two tag names separated
 with a space:
 
 ```vento
@@ -45,8 +45,8 @@ with a space:
 ## Tags in `_data`
 
 Unlike other values, when you define `tags` in a `_data.*` file and in the
-pages, the value is not overridden, but aggregated. In other words: the page
-will have all tags defined in `_data.*` **and** in the page. In the previous
-example, instead of assigning the "post" tag to all pages manually, you could
-define it in a `_data.*` file in the directory where all posts are stored and
-use the front matter to assign the other tags individually.
+pages, the value is not overridden, but merged. In other words: the page will
+have all tags defined in `_data.*` **and** in the page. In the previous example,
+instead of assigning the "post" tag to all pages manually, you could define it
+in a `_data.*` file in the directory where all posts are stored and use the
+front matter to assign the other tags individually.

--- a/docs/creating-pages/urls.md
+++ b/docs/creating-pages/urls.md
@@ -108,12 +108,13 @@ will be resolved to `/post/My first post/`). And if you are using the
 `slugify_urls` plugin, all output paths are slugified automatically, so the
 final URL would be `/post/my-first-post/`.
 
-Using functions as URLs gives a lot of flexibility to generate the URLs as you
-want.
+Using functions as URLs gives a lot of flexibility to generate URLs exactly the
+way you want.
 
 ## Setting url to `false`
 
-Setting the `url` variable to `false` prevents the page being processed by Lume.
+Setting the `url` variable to `false` prevents the page from being processed by
+Lume.
 
 ```yml
 ---
@@ -124,37 +125,37 @@ url: false # Ignore this page for now
 
 ## Basename
 
-As of Lume v2, the new variable `basename` is introduced to better customize the
-URL generation. It's a special value affecting to the page or directory where
-it's defined, and allows to change how the name of the file/directory is
-reflected to the final URL.
+As of Lume v2, the new variable `basename` is introduced to better customize URL
+generation. It's a special value affecting to the page or directory where it's
+defined, and allows changing how the name of the file/directory affects the
+final URL.
 
-If the `basename` is defined in a `_data.*` file, it affects to the directory
-where the _data file is. For example, let's say we have the following file:
+If the `basename` is defined in a `_data.*` file, it affects the directory where
+the _data file is. For example, let's say we have the following file:
 
 ```txt
 /blog/posts/hello-world.md
 ```
 
 This file is exported with the URL `/blog/posts/hello-world/`. If we want to
-replace the part `/posts/` to `/articles/`, we can create a `_data.yml` file in
-the `/blog/posts` folder with the following code:
+replace the part `/posts/` with `/articles/`, we can create a `_data.yml` file
+in the `/blog/posts` folder with the following code:
 
 ```yml
 basename: articles
 ```
 
-Now, this folder will use the name `articles` for the URL generation, so the
-final URL of the file is `/blog/articles/hello-world/`.
+Now, this folder will use the name `articles` for URL generation, so the final
+URL of the file is `/blog/articles/hello-world/`.
 
-You can set the `basename` variable to empty to don't use the folder name in the
+You can set the `basename` variable to empty to not use the folder name in the
 final URL:
 
 ```yml
 basename: ""
 ```
 
-The final URL of the file is now `/blog/hello-world/`, the `/post/` part was
+The final URL of the file is now `/blog/hello-world/`, with the `/post/` part
 removed. You can also remove the previous folder with:
 
 ```yml

--- a/docs/getting-started/create-a-layout.md
+++ b/docs/getting-started/create-a-layout.md
@@ -27,7 +27,7 @@ create a fully complete web page.
 
 Create a new directory `_includes` and the file `layout.vto` inside it. The
 `.vto` extension is for [Vento](https://vento.js.org/): a template engine
-supported by default by Lume. Insert the following code in the file:
+supported by default by Lume. Add the following code to the file:
 
 <lume-code>
 
@@ -46,8 +46,8 @@ supported by default by Lume. Insert the following code in the file:
 
 </lume-code>
 
-This layout has the `HTML` code needed to build the whole page. The tag
-`{{ content }}` is the placeholder used to insert the page content defined in
+This layout has the `HTML` code needed to build the whole page. The
+`{{ content }}` tag is a placeholder used to insert page content from
 `index.md`.
 
 > [!note]
@@ -57,10 +57,10 @@ This layout has the `HTML` code needed to build the whole page. The tag
 
 ## Assign the layout to the page
 
-Now let's configure the page (`index.md`) to use the layout just created. We
-have to create a _front matter_: a block delimited by two triple-dashed lines
-containing [YAML](https://yaml.org/) code. In this block, we define the variable
-`layout` with the value `layout.vto` (the name of the layout file).
+Now let's configure the `index.md` page to use our new layout. We have to create
+_front matter_: a block delimited by two triple-dashed lines containing
+[YAML](https://yaml.org/) code. In this block, we define the variable `layout`
+with the value `layout.vto` (the name of the layout file).
 
 <lume-code>
 

--- a/docs/getting-started/page-data.md
+++ b/docs/getting-started/page-data.md
@@ -1,6 +1,6 @@
 ---
 title: Add data to your page
-description: Working with front matters to add page data
+description: Working with front matter to add page data
 order: 3
 ---
 
@@ -24,8 +24,8 @@ I hope you enjoy it.
 
 </lume-code>
 
-This variable is accessible by the layout so that it can be inserted into the
-html code:
+This variable is accessible by the layout, so that it can be inserted into the
+generated HTML:
 
 <lume-code>
 
@@ -44,8 +44,8 @@ html code:
 
 </lume-code>
 
-The `<title>` tag has the `{{ title }}` placeholder used to insert the value of
-the variable `title`.
+The `<title>` tag uses the `{{ title }}` placeholder, which is used to insert
+the value of the `title` variable.
 
 > [!note]
 >

--- a/docs/getting-started/page-formats.md
+++ b/docs/getting-started/page-formats.md
@@ -5,15 +5,15 @@ order: 6
 ---
 
 We have seen how to create pages from Markdown files in Lume. This is a
-convenient way for text-based sites like blogs or documentation. But you may
-want to create a complex page with small texts, images, videos, animations, etc.
+convenient format for text-based sites like blogs or documentation, but you may
+want to create a complex page with small text, images, videos, animations, etc.
 Every page has its own format.
 
 ## Create pages with Vento
 
 Vento, the format we have used to create layouts in the previous examples, can
-also be used to create pages directly. You only have to create a file with the
-`.vto` extension. For example:
+also be used to create pages directly. You simply create a file with the `.vto`
+extension. For example:
 
 <lume-code>
 
@@ -47,18 +47,18 @@ links:
 
 </lume-code>
 
-This is an example of a page using Vento. Like markdown, it can contain a front
-matter to store the page data, that is used to render the Vento code. Note that
-it has the `layout` variable so the result of rendering this page will be passed
-to the layout in the `content` variable (along with the other variables `title`
-and `links`).
+This is an example of a page using Vento. Like markdown, it can contain front
+matter to store the page data, which is used to render the Vento code. Note that
+it has the `layout` variable, so the result of rendering this page will be
+passed to the layout in the `content` variable (along with the other variables
+`title` and `links`).
 
-## Create pages in JavaScript
+## Create pages with JavaScript
 
 JavaScript can be useful for complex pages requiring some logic before
 rendering. You have to create a file with the extension `.page.js`. The `.page`
-sub-extension is required to distinguish the JavaScript files to generate static
-pages from other JavaScript files destined to the executed in the browser.
+sub-extension is required to distinguish JavaScript files that generate static
+pages from other JavaScript files destined to be run in the browser.
 
 The previous Vento example in JavaScript is:
 
@@ -111,12 +111,12 @@ Lume supports several formats to generate pages.
 [Go to the Plugins section](/plugins/?status=all&data_format=on&template_engine=on)
 to see more info about all available formats. Some of them are installed by
 default (like [Vento](/plugins/vento.md), [YAML](/plugins/yaml.md),
-[Modules](/plugins/modules.md) etc) and others need to be installed in your
+[Modules](/plugins/modules.md) etc), and others need to be installed in your
 `_config.ts` file (like [Nunjucks](/plugins/nunjucks.md),
-[Eta](/plugins/eta.md), [JSX](/plugins/jsx.md), [Liquid](/plugins/liquid.md) or
+[Eta](/plugins/eta.md), [JSX](/plugins/jsx.md), [Liquid](/plugins/liquid.md), or
 [Pug](/plugins/pug.md)).
 
 ## Data model
 
-If you want to better understand how Lume load the pages, go to
+If you want to better understand how Lume loads pages, go to the
 [`Data` model](../advanced/the-data-model.md) page.

--- a/docs/getting-started/process-assets.md
+++ b/docs/getting-started/process-assets.md
@@ -8,18 +8,18 @@ In [the previous step,](./working-with-assets.md) we learned how to copy files
 to the `_site` folder. We also said that Lume has two ways of working with
 assets and copying them is the easiest.
 
-Copy files is not only the easiest way but also the fastest because Lume doesn't
-need to load the content of the files in memory. It only copies the files to the
-`_site` folder which is a fast operation.
+Copying files is not only the easiest way, but also the fastest since Lume
+doesn't need to load the content of the files in memory. It only copies the
+files to the `_site` folder, which is a fast operation.
 
 The other way to handle assets is by loading them. This is useful if you want to
-modify the content somehow. A typical use case is if we want to transpile the
-content (like loading SASS files and converting them to CSS) or minify them.
+modify the content somehow, such as transpiling (like loading SASS files and
+converting them to CSS) or minifying them.
 
-This is a bit more complex operation because we need to configure Lume to load
-these files (so they will be stored in memory) and tell Lume what we want to do
-with this content once it's loaded. Lume has two functions to do that:
-`loadAssets()` and `process()`.
+This is a more complex operation because we need to configure Lume to load these
+files (so they will be stored in memory) and tell Lume what we want to do with
+this content once it's loaded. Lume has two functions to do that: `loadAssets()`
+and `process()`.
 
 ## Minify CSS code
 

--- a/docs/getting-started/reuse-layouts.md
+++ b/docs/getting-started/reuse-layouts.md
@@ -5,7 +5,7 @@ order: 4
 ---
 
 In the [previous step](./page-data.md) we learned to define variables in the
-pages that can be used by the layouts. This allows reusing the same layout for
+pages that can be used by layouts. This allows reusing the same layout for
 multiple pages with different content.
 
 Create the file `second-page.md` in your project directory and add front matter

--- a/docs/getting-started/shared-data.md
+++ b/docs/getting-started/shared-data.md
@@ -4,14 +4,14 @@ description: Reuse the same data in multiple pages
 order: 5
 ---
 
-In [the previous step](./reuse-layouts.md) we have created two pages using the
-same layout, by setting the same `layout` variable in each. This can be fine for
-a few pages but what if you have tens, hundreds, or thousands of pages using the
+In [the previous step](./reuse-layouts.md) we created two pages using the same
+layout, by setting the same `layout` variable in each. This can be fine for a
+few pages but what if you have tens, hundreds, or thousands of pages using the
 same layout? `_data` files to the rescue!
 
 ## Create a _data file
 
-In your project directory create a `_data.yml` file with the following content:
+In your project directory, create a `_data.yml` file with the following content:
 
 <lume-code>
 
@@ -24,7 +24,7 @@ layout: layout.vto
 This is a special file containing data accessible by all pages in the same
 directory or subdirectory. In this file we have defined the variable `layout` so
 all pages have this variable too. There's no need to repeat it in the front
-matter of all pages so we can remove it there.
+matter of all pages, so we can remove it there.
 
 <lume-code>
 
@@ -59,6 +59,6 @@ This is getting better!
 
 > [!tip]
 >
-> `_data` files (and `_data` folders) are a very powerful feature of Lume.
-> [See shared data documentation](/docs/creating-pages/shared-data.md) for more
+> `_data` files (and `_data` folders) are a very powerful feature of Lume. See
+> the [shared data documentation](/docs/creating-pages/shared-data.md) for more
 > examples.

--- a/docs/getting-started/use-plugins.md
+++ b/docs/getting-started/use-plugins.md
@@ -24,8 +24,8 @@ use [lightningcss](../../plugins/lightningcss.md) a plugin to use
 minifier, that not only minifies the code but also transforms it to make it
 compatible with all browsers.
 
-To use a plugin in Lume, you have to import it in the `_config.ts` file and use
-it with the `use()` function:
+To use a plugin in Lume, you have to import it in the `_config.ts` file and
+enable it with the `use()` function:
 
 ```js
 import lume from "lume/mod.ts";
@@ -43,6 +43,6 @@ them is hidden behind the plugin. Your `_config.ts` file is now much more clean.
 > [!tip]
 >
 > Plugins are easy to use but also easy to create! Learn
-> [how to create your plugins](../advanced/plugins.md).
+> [how to create your own plugins](../advanced/plugins.md).
 
-[Go to Plugins](/plugins/) to see all official Lume plugins available.
+[Go to Plugins](/plugins/) to see all the official Lume plugins.

--- a/docs/getting-started/working-with-assets.md
+++ b/docs/getting-started/working-with-assets.md
@@ -31,7 +31,7 @@ body {
 </lume-code>
 
 Now we need to import this CSS file in all pages. Fortunately, we are using the
-same layout on all pages so we only need to edit the layout file to include a
+same layout on all pages, so we only need to edit the layout file to include a
 `<link rel="stylesheet">` element pointing to our `styles.css` file:
 
 <lume-code>
@@ -52,13 +52,13 @@ same layout on all pages so we only need to edit the layout file to include a
 
 </lume-code>
 
-Now, all pages have the `<link>` element but the styles are not applied. If you
+Now, all pages have the `<link>` element, but the styles are not applied. If you
 inspect the `_site` folder, you won't see the styles.css file there, and the URL
 `http://localhost:3000/styles.css` returns a 404 error.
 
 This is because Lume, by default, only generates HTML pages from files with
 known extensions like `.md`, `.vto`, etc. Other files are ignored. So we need to
-configure Lume to include also the extra files needed.
+configure Lume to also include our assets.
 
 Lume configuration is defined in the `_config.ts` file. When a new Lume project
 is created, this file is very basic and the only thing that it does is import

--- a/docs/overview/installation.md
+++ b/docs/overview/installation.md
@@ -4,7 +4,7 @@ description: How to install and update Lume
 order: 1
 ---
 
-As Lume is run by Deno, read the
+As Lume is built with Deno, read the
 [Deno installation](https://docs.deno.com/runtime/manual#install-deno)
 instructions if you don't have it installed yet.
 
@@ -82,7 +82,7 @@ folder to the latest version.
 
 Use the argument `--dev` to upgrade to the latest development version (the last
 commit in the [Github repository](https://github.com/lumeland/lume)). It's
-useful to test new features of Lume not yet released.
+useful to test new, unreleased Lume features.
 
 ## Vendoring
 

--- a/docs/overview/why-static-sites.md
+++ b/docs/overview/why-static-sites.md
@@ -6,21 +6,20 @@ order: 0
 
 A static website consists only of static files like HTML, CSS, JavaScript,
 images, etc. It does not use server-side processing, databases, routers, or
-rendering. Everything is pre-built, and your hosting delivers the website files
-to the browsers exactly as they appear on the server.
+rendering. Everything is pre-built, and your host delivers the website files to
+the browsers exactly as they appear on the server.
 
 In contrast, in a dynamic website, every page is generated dynamically by the
-server after any request. This allows to display of different content for each
+server after any request. This allows displaying different content for each
 visit (i.e. users who are logged in might see a different version of the page).
-Dynamic websites need some software installed in the server to work, like a
+Dynamic websites need extra software installed in the server to work, like a
 scripting language (e.g. PHP, JavaScript, Python, or Ruby), a database, etc.
 
 ## Why create static sites?
 
 Lume is a static site generator, which means it can only generate static
-websites. We believe that most websites existing today could be perfectly static
-sites and this would make them better. Why static sites are a better choice in
-most cases?
+websites. We believe that most websites could be perfectly static sites and this
+would make them better. Why are static sites a better choice in most cases?
 
 ### It's cheaper
 
@@ -29,7 +28,7 @@ very cheap or even free. There are many hosting services with generous free
 tiers for static sites like Netlify, Vercel, Cloudflare, Kinsta, etc. See
 [deployment](../advanced/deployment.md) for an extensive list of options. And if
 you decide to self-host your site, there are cheap options for less than
-$5/month in Digital Ocean, Hetzner, etc.
+$5/month on Digital Ocean, Hetzner, etc.
 
 ### Portability
 
@@ -58,15 +57,15 @@ A static site can live forever without any kind of maintenance (there's no
 database to restart, plugins to update, etc). You can upload a static site and
 forget about it for years. As long as browsers continue to exist and support
 HTML, CSS, and JavaScript, your static website will continue working like the
-first day (or even better because browsers are improving over time).
+day it was built (or better, because browsers are always getting better).
 
 ### Own your content
 
 In most static site generators, like Lume, the content is not stored in a remote
-database guarded by a private company, but in files inside your repo, with
-formats like Markdown, YAML, or JSON that you can open with any text editor.
-This makes your content completely accessible to you, and you can do whatever
-you want with it, like modify, export, move, reuse, etc.
+database guarded by a private company, but in files in your repo, with formats
+like Markdown, YAML, or JSON that you can open with any text editor. This makes
+your content completely accessible to you, and you can do whatever you want with
+it, like modify, export, move, reuse, etc.
 
 ### Better for Web sustainability
 
@@ -97,10 +96,10 @@ these site generators and want to switch to Lume. The effort needed to change
 from one static site generator to another is much lower than the effort required
 to change a dynamic site generator (i.e. from WordPress to Drupal).
 
-## What if some dynamism is needed?
+## What if some dynamic content is needed?
 
-There are some dynamic features that you may want in your website. Does it mean
-that you must switch to a dynamic site? Depending on the feature, some
+There are some dynamic features that you may want in your website. Does this
+mean that you must switch to a dynamic site? Depending on the feature, some
 alternatives can be implemented in static sites:
 
 ### Search
@@ -109,7 +108,7 @@ Searching is a basic feature of any website. Fortunately, it's possible to have
 a good search engine on your static site. There are some options:
 
 - [Pagefind](https://pagefind.app/) is a fast search library for static sites.
-  And Lume [has a plugin](../../plugins/pagefind.md) to use it.
+  Lume [has a plugin](../../plugins/pagefind.md) for it.
 - For advanced use cases, you can use a third-party service like
   [Algolia](https://www.algolia.com/) or [Orama](https://orama.com/).
 - A very basic implementation is using a search engine like DuckDuckGo to show
@@ -118,7 +117,7 @@ a good search engine on your static site. There are some options:
 
   ```html
   <form role="search" action="https://duckduckgo.com" method="GET">
-    <label>Search in lume.land <input type="search" name="q"></label>
+    <label>Search lume.land <input type="search" name="q"></label>
     <input type="hidden" name="sites" value="lume.land">
     <button>Search</button>
   </form>
@@ -127,7 +126,7 @@ a good search engine on your static site. There are some options:
   Try it now:
 
   <form role="search" action="https://duckduckgo.com" method="GET">
-    <label>Search in lume.land <input type="search" name="q"></label>
+    <label>Search lume.land <input type="search" name="q"></label>
     <input type="hidden" name="sites" value="lume.land">
     <button>Search</button>
   </form>
@@ -139,11 +138,11 @@ There are different options to manage comments in static sites:
 - Use the Fediverse.
   [mastodon-comments](https://github.com/oom-components/mastodon-comments) is a
   clever way to show comments on your posts without implementing a comment
-  system but using Mastodon and other similar platforms compatible with the
+  system using Mastodon and other similar platforms compatible with the
   Fediverse.
 - Use GitHub discussions: If you have a technical blog and most of your users
   have an account on GitHub, you can use a solution like
-  [giscus](https://giscus.app/) that uses GitHub discussions as a comment
+  [giscus](https://giscus.app/) that uses GitHub Discussions as a comment
   system.
 - Use 3rd party services like [Discus](https://disqus.com/).
 
@@ -156,9 +155,9 @@ simple tools like [Google Forms](https://docs.google.com/forms/) or
 
 ### CMS
 
-In the past, one of the main issues of static sites was that they were not easy to update by
-non-technical people. Fortunately, this is not true anymore. There are plenty of
-CMS for static sites, some recommendations:
+In the past, one of the main issues of static sites was that they were not easy
+for non-technical people to update. Fortunately, this is not true anymore. There
+are plenty of CMS for static sites, and here are some recommendations:
 
 - [LumeCMS](../../cms/index.md) can be a good solution, especially if your site
   is built with Lume (although it can work with any static site).

--- a/index.yml
+++ b/index.yml
@@ -125,7 +125,7 @@ usage:
 
       </lume-code>
 
-  - title: Store the data in your favorite format
+  - title: Store data in any format
     description: |
       Store your data using static formats like JSON or YAML. Use JavaScript or TypeScript to get the data from a Database or API.
     code: |
@@ -258,7 +258,7 @@ features:
 
   - title: Deploy anywhere
     img: /img/deploy.svg
-    description: Static sites can be hosted (for free) anywhere GitHub/GitLab Pages, Deno Deploy, Vercel, Netlify… [Explore ways to deploy](/docs/advanced/deployment.md)
+    description: Static sites can be hosted (for free) anywhere. GitHub/GitLab Pages, Deno Deploy, Vercel, Netlify… [Explore ways to deploy](/docs/advanced/deployment.md)
 
   - title: Easy to extend
     img: /img/extend.svg
@@ -391,15 +391,15 @@ support:
   contribute:
     title: How to contribute?
     description: |
-      - Star the [repo in GitHub](https://github.com/lumeland/lume) or vote in [Product Hunt](https://www.producthunt.com/posts/lume-2).
+      - Star the [repo on GitHub](https://github.com/lumeland/lume) or vote on [Product Hunt](https://www.producthunt.com/posts/lume-2).
       - Support this project by [sponsoring its creator](https://github.com/sponsors/oscarotero) or [the project](https://opencollective.com/lume).
       - Fork the repo and [contribute](https://github.com/lumeland/lume/graphs/contributors) fixing bugs or adding new features.
-      - Help to [improve the docs](https://github.com/lumeland/lume.land).
-      - Spread to the world your love for Lume in a tweet, post or any kind of publication (and let me know, [so I can include it in this page](#testimonials))
-      - Get help and propose ideas [at Discord](https://discord.gg/YbTmpACHWB).
+      - Help us [improve the docs](https://github.com/lumeland/lume.land).
+      - Spread your love for Lume in a tweet, post or any kind of publication (and let us know, [so I can include it in this page](#testimonials))
+      - Get help and propose ideas [on Discord](https://discord.gg/YbTmpACHWB).
 
 testimonials:
-  title: What people say?
+  title: What do people say about Lume?
   quotes:
     - url: https://x.com/kamilogorek/status/1881632439388532799
       author: Kamil Ogórek (@kamilogorek)


### PR DESCRIPTION
This was mentioned on the Lume discord, and this is the first step of helping to clean up Lume's documentation to ensure its grammar is clean and the wording makes sense.