### PR TITLE
Update /plugins link branch to main

### DIFF
--- a/docs/advanced/plugins.md
+++ b/docs/advanced/plugins.md
@@ -83,7 +83,7 @@ they provide a better interface to organize, reuse, and even share your code
 with others.
 
 Take a look at the
-[Lume plugins repository](https://github.com/lumeland/lume/tree/master/plugins)
+[Lume plugins repository](https://github.com/lumeland/lume/tree/main/plugins)
 for more advanced examples.
 
 ## Hooks


### PR DESCRIPTION
This link at the end of https://lume.land/docs/advanced/plugins/#simple-plugin-example needs to be `main` not `master` now

> Take a look at the [Lume plugins repository](https://github.com/lumeland/lume/tree/master/plugins) for more advanced examples. 

Updated to https://github.com/lumeland/lume/tree/main/plugins