### PR TITLE
Fix missing commas in markdown.md

### DIFF
--- a/cms/fields/markdown.md
+++ b/cms/fields/markdown.md
@@ -56,11 +56,11 @@ the currently selected text.
   type: "markdown",
   snippets: [
     {
-      label: "copyright"
-      value: "© Acme inc, 2025"
+      label: "copyright",
+      value: "© Acme Inc, 2025"
     },
     {
-      label: "Keyboard input"
+      label: "Keyboard input",
       value: "<kbd>{$}</kbd>"
     },
   ]


### PR DESCRIPTION
The snippets feature is nice, thanks! There were missing commas in the sample config, which I copied as is to test, then saw an error. A quick fix.