### PR TITLE
Changed Eta text insertion tag `<%=` to html insertion tag `<%~` in c…

### DIFF
--- a/docs/core/components.md
+++ b/docs/core/components.md
@@ -81,7 +81,7 @@ Eta templates:
 
 ```html
 <h1>Welcome to my site.</h1>
-<%= await comp.button({ text: "Login" }) %>
+<%~ await comp.button({ text: "Login" }) %>
 ```
 
 Lume components can be used like JSX components if you're using the JSX plugin:


### PR DESCRIPTION
`<%=` --> `<%~` for using components in Eta

Eta, like many other template languages, escapes xml/html by default. To get around this, the `<%~` opening tag was created https://eta.js.org/docs/intro/template-syntax