### PR TITLE
updated docs option root. Netlify support

### DIFF
--- a/cms/configuration/options.md
+++ b/cms/configuration/options.md
@@ -24,6 +24,13 @@ This is the root directory of the site you want to edit. Lume automatically set
 this value to the `src` folder. It's used to file system storage
 [when it's defined as a string](./storage.md#file-system).
 
+> [!note]
+>
+> If you do not specify a `root` option, the CMS will use `Deno.cwd()` to get
+> the current working directory. Some Deno platforms (like Netlify edge-functions)
+> do not support Deno file system access and will fatally error when `Deno.cwd()`
+> is executed. Provide an empty string `""` as the root option to avoid this.
+
 ### basePath
 
 The public base path of the CMS. Lume adapter set this value to `/admin`.


### PR DESCRIPTION
Hi Oscar, Kyle here from Discord.

Once again thank you for your continued efforts to get Lume CMS working on multiple edge platforms.

This is just a proposed doc change explaining why the `root` option is needed if using Netlify edge-functions.. or any platform that doesn't support Deno file system access.

Cheers!