### PR TITLE
Reword sentence in `expires.md` middleware doc

### DIFF
--- a/plugins/expires.md
+++ b/plugins/expires.md
@@ -34,5 +34,5 @@ server.start();
 ### Local development
 
 It's not recommended to use this middleware in local development because the
-whole point of a local server is to don't cache resources and ensure to serve
-the most fresh version.
+whole point of a local server is to not cache resources and to ensure serving
+the most fresh version of your content.


### PR DESCRIPTION
I intended to just fix the typo (`don't` => `not`), but I thought rewording wouldn't hurt