### PR TITLE
docs(deployment): cache deno dependencies in example

### DIFF
--- a/docs/advanced/deployment.md
+++ b/docs/advanced/deployment.md
@@ -57,6 +57,8 @@ jobs:
 
       - name: Setup Deno environment
         uses: denoland/setup-deno@v2
+        with:
+          cache: true
 
       - name: Build site
         run: deno task build


### PR DESCRIPTION
see: https://github.com/marketplace/actions/setup-deno#caching-dependencies-downloaded-by-deno-automatically