### PR TITLE
Add basic usage example for `lume_markdown_plugins`

### DIFF
--- a/plugins/markdown.md
+++ b/plugins/markdown.md
@@ -99,7 +99,41 @@ const site = lume({}, { markdown });
 The repository
 [lume_markdown_plugins](https://deno.land/x/lume_markdown_plugins) contain a
 collection of plugins specially adapted to Lume, with useful features like
-extract the title from the markdown or generate a table of contents.
+extract the title from the markdown or generate a table of contents. To use
+these plugins, you might need to first add them to your imports map in `deno.json`:
+
+```json
+{
+  "imports": {
+    "lume_markdown_plugins/": "https://deno.land/x/lume_markdown_plugins@v0.9.0/"
+  }
+}
+```
+
+Then in your site config file, apply them to the site:
+
+```ts
+import footnotes from "lume_markdown_plugins/footnotes.ts";
+
+const site = lume()
+  .use(footnotes());
+
+export default site;
+```
+Last, you will need to write the code to render the extracted footnotes in your template:
+```vto
+ {{ if footnotes.length }}
+  <ul>
+    {{ for note of footnotes }}
+    <li id={{ note.id }}>
+      {{ note.content }}
+      <a href="#{{ note.refId }}" class="footnote-backref">↩</a>
+    </li>
+    {{ /for }}
+  </ul>
+ {{ /if }}
+```
+You can check out the full [demo](https://github.com/lumeland/markdown-plugins/tree/main/footnotes/demo)  for more details. In fact, each lume markdown plugin has a demo to illustrate its usage.
 
 ## Hooks
 

--- a/scripts/components/lume_devices.js
+++ b/scripts/components/lume_devices.js
@@ -2,7 +2,7 @@ export default class LumeDevices extends HTMLElement {
   connectedCallback() {
     const form = this.querySelector("form");
     const screens = this.querySelectorAll(".device");
-    const init = new URLSearchParams(window.location.search);
+    const init = new URLSearchParams(globalThis.location.search);
 
     for (const [key, value] of init.entries()) {
       const input = form[key];

--- a/scripts/vendor/carousel/carousel.js
+++ b/scripts/vendor/carousel/carousel.js
@@ -62,7 +62,7 @@ export default class Carousel extends HTMLElement {
     }
 
     //Resize observer
-    if (window.ResizeObserver) {
+    if (globalThis.ResizeObserver) {
       if (!observer) {
         observer = new ResizeObserver((entries) => {
           for (const entry of entries) {


### PR DESCRIPTION
# My modification
As a new user of both Deno and Lume, I found the doc missing some basic examples. This commit adds one for lume_markdown_plugins.

markdown-it-footnote was written in JavaScript and has not been actively maintained [^1]. This is a valid chance (I think) to recomment plugins written in TypesScript and especially those that are designed to be used with Lume.

[^1]: last committed 2 years ago: https://github.com/markdown-it/markdown-it-footnote

I also found [@mdit/plugin-footnote](https://mdit-plugins.github.io/footnote.html) to be great to use with Lume and is a good drop-in replacement for markdown-it-footnote. You may consider using that one (or some of them [^2]) in the example of the section of Hooks.

[^2]: `@mdit/plugins` are written in TypeScript. I think they are modern and well maintained: https://mdit-plugins.github.io/

# `deno lint` result
```
error[no-window]: Window is no longer available in Deno
 --> /home/noel/projects/lume.land/scripts/components/lume_devices.js:5:38
  | 
5 |     const init = new URLSearchParams(window.location.search);
  |                                      ^^^^^^
  = hint: Instead, use `globalThis`

  docs: https://docs.deno.com/lint/rules/no-window


error[no-window]: Window is no longer available in Deno
  --> /home/noel/projects/lume.land/scripts/vendor/carousel/carousel.js:65:9
   | 
65 |     if (window.ResizeObserver) {
   |         ^^^^^^
   = hint: Instead, use `globalThis`

  docs: https://docs.deno.com/lint/rules/no-window
```
But I didn't touch any of the above files and since I'm new to Deno and Lume, I don't know what would be a proper fix. I post it here just for your information.