### PR TITLE
Make the default import consistent in doc for codeHighlight plugin

### DIFF
--- a/plugins/code_highlight.md
+++ b/plugins/code_highlight.md
@@ -9,7 +9,7 @@ tags:
 ## Description
 
 This plugin uses the [highlight.js](https://highlightjs.org/) library to search
-and highlight the syntax code of any `<pre><code>` element.
+and highlight the code syntax in any `<pre><code>` element.
 
 ## Installation
 
@@ -28,22 +28,23 @@ export default site;
 
 ## Languages
 
-`Highlight.js` has support for several languages by default. You can see
+`Highlight.js` supports many languages by default. You can see
 [a list of supported languages](https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md).
-Use the `languages` key to register additional languages:
+You can (and probably should) use the `languages` option key to register only
+the languages you need:
 
 ```js
 import lume from "lume/mod.ts";
-import code_highlight from "lume/plugins/code_highlight.ts";
+import codeHighlight from "lume/plugins/code_highlight.ts";
 
-// import your favorite language
+// import your preferred language
 import lang_javascript from "npm:highlight.js/lib/languages/javascript";
 import lang_bash from "npm:highlight.js/lib/languages/bash";
 
 const site = lume();
 
 site.use(
-  code_highlight({
+  codeHighlight({
     languages: {
       javascript: lang_javascript,
       bash: lang_bash,
@@ -59,7 +60,7 @@ export default site;
 To properly highlight the syntax of your code, you need CSS code compatible with
 Highlight.js classes. This library provides some
 [pre-made themes](https://highlightjs.org/examples) that you can download
-automatically with the `theme` option:
+automatically using the `theme` option:
 
 ```ts
 import lume from "lume/mod.ts";
@@ -67,27 +68,27 @@ import highlight from "lume/plugins/code_highlight.ts";
 
 const site = lume();
 
-site.use(highlight({
+site.use(codeHighlight({
   theme: {
     name: "atom-one-dark", // The theme name to download
     cssFile: "/styles.css", // The destination filename
-    placeholder: "/* insert-theme-here */", // Optional placeholder to replace with the final code
+    placeholder: "/* insert-theme-here */", // Optional placeholder to replace with the theme code
   },
 }));
 
 export default site;
 ```
 
-If you want to use different themes (for example for dark and light mode), you
+If you want to use multiple themes (for example for dark and light mode), you
 can provide an array of themes:
 
 ```ts{title="_config.ts"}
 import lume from "lume/mod.ts";
-import highlight from "lume/plugins/code_highlight.ts";
+import codeHighlight from "lume/plugins/code_highlight.ts";
 
 const site = lume();
 
-site.use(highlight({
+site.use(codeHighlight({
   theme: [
     {
       name: "atom-one-light",


### PR DESCRIPTION
I made a few minor modifications to the doc of code highlight plugin:
1. consistent import/default will not confuse users (especially those not familiar with JS modules)
2. slightly rephrased a few lines

But I admit this might not be necessary. Feel free to close it if you prefer to stick to the original version :)