### PR TITLE
Rephrase a few sentences for jsx page doc and mdx doc

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -9,7 +9,7 @@ import transformImages from "lume/plugins/transform_images.ts";
 import favicon from "lume/plugins/favicon.ts";
 import minifyHTML from "lume/plugins/minify_html.ts";
 import postcss from "lume/plugins/postcss.ts";
-import nesting from "npm:postcss-nesting";
+import nesting from "npm:postcss-nesting@13.0.2";
 import sitemap from "lume/plugins/sitemap.ts";
 import metas from "lume/plugins/metas.ts";
 import checkUrls from "lume/plugins/check_urls.ts";

--- a/plugins/jsx.md
+++ b/plugins/jsx.md
@@ -84,7 +84,7 @@ export default (data: Lume.Data, helpers: Lume.Helpers) => (
 ```
 
 Note that this page uses the `layouts/main.vto` Vento layout to wrap the
-content. (You can mix different template languages like Nunjucks and JSX.)
+content. Apart from setting the page frontmatter via variables as above, you can use the flexible `_data.*` file or directory (see [Shared data](../docs/creating-pages/shared-data.md)) to that end. Also, you can mix different template languages like Nunjucks and JSX.
 
 ## Creating layouts
 

--- a/plugins/mdx.md
+++ b/plugins/mdx.md
@@ -52,8 +52,8 @@ export default site;
 
 ## Components
 
-In MDX you can use the Lume components from the `comp` global variable variable
-or import other components like in JavaScript (with `import ... from ...`):
+In MDX you can use the Lume components from the global variable `comp` or import
+other components like in JavaScript (with `import ... from ...`):
 
 ```html
 ---


### PR DESCRIPTION
1. I tried to make it clear that `layout` needs to be declared in a JSX page to actually use it
2. I made a small fix to the MDX doc

Running `deno lint` gives me the below error:
```
error[no-unversioned-import]: Missing version in specifier
  --> /home/noel/projects/lume.land/_config.ts:12:21
   | 
12 | import nesting from "npm:postcss-nesting";
   |                     ^^^^^^^^^^^^^^^^^^^^^
   = hint: Add a version requirement after the package name

  docs: https://docs.deno.com/lint/rules/no-unversioned-import
```
Could you let me know how can I fix this properly?