### PR TITLE
Add lume_nueglow plugin

### DIFF
--- a/plugins/index.yml
+++ b/plugins/index.yml
@@ -83,3 +83,7 @@ plugins:
   - title: lume-mermaid
     description: A plugin for Lume to render Mermaid diagrams.
     url: https://github.com/wewillcraft/lume-mermaid
+
+  - title: Nueglow
+    description: Lume plugin that adds syntax highlighting with Nueglow
+    url: https://github.com/ethmarks/lume_nueglow


### PR DESCRIPTION
Hi! I'd like to add my lume_nueglow plugin: <https://github.com/ethmarks/lume_nueglow>. 

I've prepared a demo built with Lume and my plugin here: <https://ethmarks.github.io/lume_nueglow/>.

I made my plugin because I noticed that ArnavK-09's [lume_glow plugin](https://github.com/ArnavK-09/lume_glow) doesn't seem to be working anymore[^1] and it doesn't seem to be actively maintained, so I made a successor. I wanted to share it with the Lume community in case anyone else ran into the same issue with lume_glow that I did.

This is my first OSS contribution, so please let me know if I've done anything incorrectly! Thanks!

~Ethan

[^1]: I think that it's because lume_glow uses external asset URLs that throw 404s now, so the plugin just injects `<style>404: Not Foundpre { overflow-x: auto }</style>` into the head of every page. See this gist for an example: <https://gist.github.com/ethmarks/64897a43d47654fe9d314e81ea8ed6c1>.