### PR TITLE
Codeberg section now says "Codeberg" instead of "GitLab"

### DIFF
--- a/cms/configuration/storage.md
+++ b/cms/configuration/storage.md
@@ -155,7 +155,7 @@ export default cms;
 
 ## Codeberg
 
-It's similar to GitHub but for GitLab:
+It's similar to GitHub but for [Codeberg](https://codeberg.org):
 
 ```ts
 import lumeCMS from "lume/cms/mod.ts";


### PR DESCRIPTION
Updated Codeberg reference to include a link; replaced the erroneous mention of GitLab.